### PR TITLE
Optimize the initialization of bounds data on GPU

### DIFF
--- a/lib/pfsp/Bound_johnson.chpl
+++ b/lib/pfsp/Bound_johnson.chpl
@@ -22,10 +22,10 @@ module Bound_johnson
 
     proc init() {}
 
-    proc init(const lb1_data: lb1_bound_data/*, enum lb2_variant lb2_type*/)
+    proc init(const jobs: int, const machines: int/*, enum lb2_variant lb2_type*/)
     {
-      this.nb_jobs = lb1_data.nb_jobs;
-      this.nb_machines = lb1_data.nb_machines;
+      this.nb_jobs = jobs;
+      this.nb_machines = machines;
 
       var lb2_type = lb2_variant.LB2_FULL;
 
@@ -48,9 +48,9 @@ module Bound_johnson
   class WrapperClassLB2 {
     forwarding var lb2_bound: lb2_bound_data;
 
-    proc init(const lb1_data: lb1_bound_data)
+    proc init(const jobs: int, const machines: int)
     {
-      this.lb2_bound = new lb2_bound_data(lb1_data);
+      this.lb2_bound = new lb2_bound_data(jobs, machines);
     }
   }
 

--- a/lib/pfsp/Bound_johnson.chpl
+++ b/lib/pfsp/Bound_johnson.chpl
@@ -7,12 +7,14 @@ module Bound_johnson
 
   record lb2_bound_data
   {
+    // constants
     var nb_jobs: int;
     var nb_machines: int;
     var nb_machine_pairs: int;
-
+    // domains
     var ld: domain(1);
     var ad: domain(1);
+    // data arrays
     var johnson_schedules: [ld] int;
     var lags: [ld] int;
     var machine_pairs: [0..1] [ad] int;

--- a/lib/pfsp/Bound_johnson.chpl
+++ b/lib/pfsp/Bound_johnson.chpl
@@ -41,12 +41,6 @@ module Bound_johnson
 
       this.ld = {0..#this.nb_machine_pairs*this.nb_jobs};
       this.ad = {0..#this.nb_machine_pairs};
-
-      init this;
-
-      fill_machine_pairs(this/*, LB2_FULL*/);
-      fill_lags(lb1_data.p_times, this);
-      fill_johnson_schedules(lb1_data.p_times, this);
     }
   }
 

--- a/lib/pfsp/Bound_simple.chpl
+++ b/lib/pfsp/Bound_simple.chpl
@@ -2,20 +2,24 @@ module Bound_simple
 {
   record lb1_bound_data
   {
-    var ptd: domain(1);
-    var p_times: [ptd] int;
-    var md: domain(1);
-    var min_heads: [md] int;    // for each machine k, minimum time between t=0 and start of any job
-    var min_tails: [md] int;    // for each machine k, minimum time between release of any job and end of processing on the last machine
+    // constants
     var nb_jobs: int;
     var nb_machines: int;
+    // domains
+    var ptd: domain(1);
+    var md: domain(1);
+    // data arrays
+    var p_times: [ptd] int;
+    var min_heads: [md] int; // for each machine k, minimum time between t=0 and start of any job
+    var min_tails: [md] int; // for each machine k, minimum time between release of any job and end of processing on the last machine
 
-    proc init(jobs: int, machines: int)
+    proc init(const jobs: int, const machines: int)
     {
-      this.ptd = {0..#(jobs*machines)};
-      this.md = {0..#machines};
       this.nb_jobs = jobs;
       this.nb_machines = machines;
+
+      this.ptd = {0..#(jobs*machines)};
+      this.md = {0..#machines};
     }
   }
 
@@ -23,7 +27,7 @@ module Bound_simple
   class WrapperClassLB1 {
     forwarding var lb1_bound: lb1_bound_data;
 
-    proc init(jobs: int, machines: int)
+    proc init(const jobs: int, const machines: int)
     {
       this.lb1_bound = new lb1_bound_data(jobs, machines);
     }

--- a/pfsp_chpl.chpl
+++ b/pfsp_chpl.chpl
@@ -60,7 +60,10 @@ var lbound1 = new lb1_bound_data(jobs, machines);
 taillard_get_processing_times(lbound1.p_times, inst);
 fill_min_heads_tails(lbound1);
 
-const lbound2 = new lb2_bound_data(lbound1);
+var lbound2 = new lb2_bound_data(lbound1);
+fill_machine_pairs(lbound2/*, LB2_FULL*/);
+fill_lags(lbound1.p_times, lbound2);
+fill_johnson_schedules(lbound1.p_times, lbound2);
 
 const initUB = if (ub == 1) then taillard_get_best_ub(inst) else max(int);
 

--- a/pfsp_chpl.chpl
+++ b/pfsp_chpl.chpl
@@ -60,7 +60,7 @@ var lbound1 = new lb1_bound_data(jobs, machines);
 taillard_get_processing_times(lbound1.p_times, inst);
 fill_min_heads_tails(lbound1);
 
-var lbound2 = new lb2_bound_data(lbound1);
+var lbound2 = new lb2_bound_data(jobs, machines);
 fill_machine_pairs(lbound2/*, LB2_FULL*/);
 fill_lags(lbound1.p_times, lbound2);
 fill_johnson_schedules(lbound1.p_times, lbound2);

--- a/pfsp_dist_multigpu_chpl.chpl
+++ b/pfsp_dist_multigpu_chpl.chpl
@@ -367,7 +367,10 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
   taillard_get_processing_times(lbound1_p!.lb1_bound.p_times, inst);
   fill_min_heads_tails(lbound1_p!.lb1_bound);
 
-  const lbound2_p = new WrapperLB2(lbound1_p!.lb1_bound);
+  var lbound2_p = new WrapperLB2(lbound1_p!.lb1_bound);
+  fill_machine_pairs(lbound2_p!.lb2_bound/*, LB2_FULL*/);
+  fill_lags(lbound1_p!.lb1_bound.p_times, lbound2_p!.lb2_bound);
+  fill_johnson_schedules(lbound1_p!.lb1_bound.p_times, lbound2_p!.lb2_bound);
 
   while (pool.size < D*m*numLocales) {
     var hasWork = 0;
@@ -444,7 +447,10 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
       taillard_get_processing_times(lbound1!.lb1_bound.p_times, inst);
       fill_min_heads_tails(lbound1!.lb1_bound);
 
-      const lbound2 = new WrapperLB2(lbound1!.lb1_bound);
+      var lbound2 = new WrapperLB2(lbound1!.lb1_bound);
+      fill_machine_pairs(lbound2!.lb2_bound/*, LB2_FULL*/);
+      fill_lags(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
+      fill_johnson_schedules(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
 
       var lbound1_d: lbound1.type;
       var lbound2_d: lbound2.type;
@@ -455,6 +461,9 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
         fill_min_heads_tails(lbound1_d!.lb1_bound);
 
         lbound2_d = new WrapperLB2(lbound1_d!.lb1_bound);
+        fill_machine_pairs(lbound2_d!.lb2_bound/*, LB2_FULL*/);
+        fill_lags(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
+        fill_johnson_schedules(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
       }
 
       while true {

--- a/pfsp_dist_multigpu_chpl.chpl
+++ b/pfsp_dist_multigpu_chpl.chpl
@@ -367,7 +367,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
   taillard_get_processing_times(lbound1_p!.lb1_bound.p_times, inst);
   fill_min_heads_tails(lbound1_p!.lb1_bound);
 
-  var lbound2_p = new WrapperLB2(lbound1_p!.lb1_bound);
+  var lbound2_p = new WrapperLB2(jobs, machines);
   fill_machine_pairs(lbound2_p!.lb2_bound/*, LB2_FULL*/);
   fill_lags(lbound1_p!.lb1_bound.p_times, lbound2_p!.lb2_bound);
   fill_johnson_schedules(lbound1_p!.lb1_bound.p_times, lbound2_p!.lb2_bound);
@@ -447,7 +447,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
       taillard_get_processing_times(lbound1!.lb1_bound.p_times, inst);
       fill_min_heads_tails(lbound1!.lb1_bound);
 
-      var lbound2 = new WrapperLB2(lbound1!.lb1_bound);
+      var lbound2 = new WrapperLB2(jobs, machines);
       fill_machine_pairs(lbound2!.lb2_bound/*, LB2_FULL*/);
       fill_lags(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
       fill_johnson_schedules(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
@@ -460,7 +460,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
         taillard_get_processing_times(lbound1_d!.lb1_bound.p_times, inst);
         fill_min_heads_tails(lbound1_d!.lb1_bound);
 
-        lbound2_d = new WrapperLB2(lbound1_d!.lb1_bound);
+        lbound2_d = new WrapperLB2(jobs, machines);
         fill_machine_pairs(lbound2_d!.lb2_bound/*, LB2_FULL*/);
         fill_lags(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
         fill_johnson_schedules(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);

--- a/pfsp_dist_multigpu_chpl.chpl
+++ b/pfsp_dist_multigpu_chpl.chpl
@@ -457,13 +457,15 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
 
       on gpu {
         lbound1_d = new WrapperLB1(jobs, machines);
-        taillard_get_processing_times(lbound1_d!.lb1_bound.p_times, inst);
-        fill_min_heads_tails(lbound1_d!.lb1_bound);
+        lbound1_d!.lb1_bound.p_times   = lbound1!.lb1_bound.p_times;
+        lbound1_d!.lb1_bound.min_heads = lbound1!.lb1_bound.min_heads;
+        lbound1_d!.lb1_bound.min_tails = lbound1!.lb1_bound.min_tails;
 
         lbound2_d = new WrapperLB2(jobs, machines);
-        fill_machine_pairs(lbound2_d!.lb2_bound/*, LB2_FULL*/);
-        fill_lags(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
-        fill_johnson_schedules(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
+        lbound2_d!.lb2_bound.johnson_schedules  = lbound2!.lb2_bound.johnson_schedules;
+        lbound2_d!.lb2_bound.lags               = lbound2!.lb2_bound.lags;
+        lbound2_d!.lb2_bound.machine_pairs      = lbound2!.lb2_bound.machine_pairs;
+        lbound2_d!.lb2_bound.machine_pair_order = lbound2!.lb2_bound.machine_pair_order;
       }
 
       while true {

--- a/pfsp_gpu_chpl.chpl
+++ b/pfsp_gpu_chpl.chpl
@@ -71,7 +71,7 @@ var lbound1 = new WrapperLB1(jobs, machines); //lb1_bound_data(jobs, machines);
 taillard_get_processing_times(lbound1!.lb1_bound.p_times, inst);
 fill_min_heads_tails(lbound1!.lb1_bound);
 
-var lbound2 = new WrapperLB2(lbound1!.lb1_bound);
+var lbound2 = new WrapperLB2(jobs, machines);
 fill_machine_pairs(lbound2!.lb2_bound/*, LB2_FULL*/);
 fill_lags(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
 fill_johnson_schedules(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
@@ -374,7 +374,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
     taillard_get_processing_times(lbound1_d!.lb1_bound.p_times, inst);
     fill_min_heads_tails(lbound1_d!.lb1_bound);
 
-    lbound2_d = new WrapperLB2(lbound1_d!.lb1_bound);
+    lbound2_d = new WrapperLB2(jobs, machines);
     fill_machine_pairs(lbound2_d!.lb2_bound/*, LB2_FULL*/);
     fill_lags(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
     fill_johnson_schedules(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);

--- a/pfsp_gpu_chpl.chpl
+++ b/pfsp_gpu_chpl.chpl
@@ -371,13 +371,15 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
 
   on here.gpus[0] {
     lbound1_d = new WrapperLB1(jobs, machines);
-    taillard_get_processing_times(lbound1_d!.lb1_bound.p_times, inst);
-    fill_min_heads_tails(lbound1_d!.lb1_bound);
+    lbound1_d!.lb1_bound.p_times   = lbound1!.lb1_bound.p_times;
+    lbound1_d!.lb1_bound.min_heads = lbound1!.lb1_bound.min_heads;
+    lbound1_d!.lb1_bound.min_tails = lbound1!.lb1_bound.min_tails;
 
     lbound2_d = new WrapperLB2(jobs, machines);
-    fill_machine_pairs(lbound2_d!.lb2_bound/*, LB2_FULL*/);
-    fill_lags(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
-    fill_johnson_schedules(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
+    lbound2_d!.lb2_bound.johnson_schedules  = lbound2!.lb2_bound.johnson_schedules;
+    lbound2_d!.lb2_bound.lags               = lbound2!.lb2_bound.lags;
+    lbound2_d!.lb2_bound.machine_pairs      = lbound2!.lb2_bound.machine_pairs;
+    lbound2_d!.lb2_bound.machine_pair_order = lbound2!.lb2_bound.machine_pair_order;
   }
 
   while true {

--- a/pfsp_gpu_chpl.chpl
+++ b/pfsp_gpu_chpl.chpl
@@ -71,7 +71,10 @@ var lbound1 = new WrapperLB1(jobs, machines); //lb1_bound_data(jobs, machines);
 taillard_get_processing_times(lbound1!.lb1_bound.p_times, inst);
 fill_min_heads_tails(lbound1!.lb1_bound);
 
-const lbound2 = new WrapperLB2(lbound1!.lb1_bound);
+var lbound2 = new WrapperLB2(lbound1!.lb1_bound);
+fill_machine_pairs(lbound2!.lb2_bound/*, LB2_FULL*/);
+fill_lags(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
+fill_johnson_schedules(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
 
 const initUB = if (ub == 1) then taillard_get_best_ub(inst) else max(int);
 
@@ -372,6 +375,9 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
     fill_min_heads_tails(lbound1_d!.lb1_bound);
 
     lbound2_d = new WrapperLB2(lbound1_d!.lb1_bound);
+    fill_machine_pairs(lbound2_d!.lb2_bound/*, LB2_FULL*/);
+    fill_lags(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
+    fill_johnson_schedules(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
   }
 
   while true {

--- a/pfsp_multigpu_chpl.chpl
+++ b/pfsp_multigpu_chpl.chpl
@@ -432,13 +432,15 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
 
     on gpu {
       lbound1_d = new WrapperLB1(jobs, machines);
-      taillard_get_processing_times(lbound1_d!.lb1_bound.p_times, inst);
-      fill_min_heads_tails(lbound1_d!.lb1_bound);
+      lbound1_d!.lb1_bound.p_times   = lbound1!.lb1_bound.p_times;
+      lbound1_d!.lb1_bound.min_heads = lbound1!.lb1_bound.min_heads;
+      lbound1_d!.lb1_bound.min_tails = lbound1!.lb1_bound.min_tails;
 
       lbound2_d = new WrapperLB2(jobs, machines);
-      fill_machine_pairs(lbound2_d!.lb2_bound/*, LB2_FULL*/);
-      fill_lags(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
-      fill_johnson_schedules(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
+      lbound2_d!.lb2_bound.johnson_schedules  = lbound2!.lb2_bound.johnson_schedules;
+      lbound2_d!.lb2_bound.lags               = lbound2!.lb2_bound.lags;
+      lbound2_d!.lb2_bound.machine_pairs      = lbound2!.lb2_bound.machine_pairs;
+      lbound2_d!.lb2_bound.machine_pair_order = lbound2!.lb2_bound.machine_pair_order;
     }
 
     while true {

--- a/pfsp_multigpu_chpl.chpl
+++ b/pfsp_multigpu_chpl.chpl
@@ -367,7 +367,10 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
   taillard_get_processing_times(lbound1_p!.lb1_bound.p_times, inst);
   fill_min_heads_tails(lbound1_p!.lb1_bound);
 
-  const lbound2_p = new WrapperLB2(lbound1_p!.lb1_bound);
+  var lbound2_p = new WrapperLB2(lbound1_p!.lb1_bound);
+  fill_machine_pairs(lbound2_p!.lb2_bound/*, LB2_FULL*/);
+  fill_lags(lbound1_p!.lb1_bound.p_times, lbound2_p!.lb2_bound);
+  fill_johnson_schedules(lbound1_p!.lb1_bound.p_times, lbound2_p!.lb2_bound);
 
   while (pool.size < D*m) {
     var hasWork = 0;
@@ -419,7 +422,10 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
     taillard_get_processing_times(lbound1!.lb1_bound.p_times, inst);
     fill_min_heads_tails(lbound1!.lb1_bound);
 
-    const lbound2 = new WrapperLB2(lbound1!.lb1_bound);
+    var lbound2 = new WrapperLB2(lbound1!.lb1_bound);
+    fill_machine_pairs(lbound2!.lb2_bound/*, LB2_FULL*/);
+    fill_lags(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
+    fill_johnson_schedules(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
 
     var lbound1_d: lbound1.type;
     var lbound2_d: lbound2.type;
@@ -430,6 +436,9 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
       fill_min_heads_tails(lbound1_d!.lb1_bound);
 
       lbound2_d = new WrapperLB2(lbound1_d!.lb1_bound);
+      fill_machine_pairs(lbound2_d!.lb2_bound/*, LB2_FULL*/);
+      fill_lags(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
+      fill_johnson_schedules(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
     }
 
     while true {

--- a/pfsp_multigpu_chpl.chpl
+++ b/pfsp_multigpu_chpl.chpl
@@ -367,7 +367,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
   taillard_get_processing_times(lbound1_p!.lb1_bound.p_times, inst);
   fill_min_heads_tails(lbound1_p!.lb1_bound);
 
-  var lbound2_p = new WrapperLB2(lbound1_p!.lb1_bound);
+  var lbound2_p = new WrapperLB2(jobs, machines);
   fill_machine_pairs(lbound2_p!.lb2_bound/*, LB2_FULL*/);
   fill_lags(lbound1_p!.lb1_bound.p_times, lbound2_p!.lb2_bound);
   fill_johnson_schedules(lbound1_p!.lb1_bound.p_times, lbound2_p!.lb2_bound);
@@ -422,7 +422,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
     taillard_get_processing_times(lbound1!.lb1_bound.p_times, inst);
     fill_min_heads_tails(lbound1!.lb1_bound);
 
-    var lbound2 = new WrapperLB2(lbound1!.lb1_bound);
+    var lbound2 = new WrapperLB2(jobs, machines);
     fill_machine_pairs(lbound2!.lb2_bound/*, LB2_FULL*/);
     fill_lags(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
     fill_johnson_schedules(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
@@ -435,7 +435,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
       taillard_get_processing_times(lbound1_d!.lb1_bound.p_times, inst);
       fill_min_heads_tails(lbound1_d!.lb1_bound);
 
-      lbound2_d = new WrapperLB2(lbound1_d!.lb1_bound);
+      lbound2_d = new WrapperLB2(jobs, machines);
       fill_machine_pairs(lbound2_d!.lb2_bound/*, LB2_FULL*/);
       fill_lags(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);
       fill_johnson_schedules(lbound1_d!.lb1_bound.p_times, lbound2_d!.lb2_bound);


### PR DESCRIPTION
In the current approach, we initialize the data arrays on GPU and recompute them from scratch, inducing kernel launches and many host/Device communications. In the optimized version, we simply copy on the GPU the data arrays computed on the CPU.

Example of improvements using ta014 in single-GPU mode:

Stats | Current | Improved
--------------|---------|-------------
kernel launches | 11 | 8 
host_to_device comms | 11,190 | 10
device_to_host comms | 26,179 | 2
device_to_device comms | 0 | 0