### PR TITLE
Add a dynamic work stealing mechanism for Chapel multi-GPU code

### DIFF
--- a/lib/common/Pool.chpl
+++ b/lib/common/Pool.chpl
@@ -17,8 +17,8 @@ module Pool
     var front: int;
     var size: int;
 
-    proc init(type elemType) {
-      this.eltType = elemType;
+    proc init(type eltType) {
+      this.eltType = eltType;
       this.dom = 0..#CAPACITY;
       this.capacity = CAPACITY;
     }

--- a/lib/common/Pool_ext.chpl
+++ b/lib/common/Pool_ext.chpl
@@ -7,7 +7,7 @@ module Pool_ext
   'pushBack' and 'popBack' operations.
   *******************************************************************************/
 
-  config param CAPACITY = 1024;
+  config param CAPACITY = 1024000;
 
   record SinglePool_ext {
     type eltType;
@@ -16,24 +16,74 @@ module Pool_ext
     var capacity: int;
     var front: int;
     var size: int;
+    var lock: atomic bool;
 
     proc init(type eltType) {
       this.eltType = eltType;
-      this.dom = 0..#CAPACITY;
+      this.dom = {0..#CAPACITY};
       this.capacity = CAPACITY;
+      this.lock = false;
     }
 
     proc ref pushBack(node: eltType) {
-      if (this.front + this.size >= this.capacity) {
-        this.capacity *= 2;
-        this.dom = 0..#this.capacity;
-      }
+      while true {
+        if this.lock.compareAndSwap(false, true) {
+          if (this.front + this.size >= this.capacity) {
+            this.capacity *= 2;
+            this.dom = 0..#this.capacity;
+          }
 
-      this.elements[this.front + this.size] = node;
-      this.size += 1;
+          this.elements[this.front + this.size] = node;
+          this.size += 1;
+          this.lock.write(false);
+          return;
+        }
+      }
+    }
+
+    proc ref pushBackBulk(nodes: [] eltType) {
+      const s = nodes.size;
+
+      while true {
+        if this.lock.compareAndSwap(false, true) {
+          /*
+            TODO: Implement dynamic-size mechanism in that case.
+          */
+          /* if (this.front + this.size >= this.capacity) {
+            this.capacity *= 2;
+            this.dom = 0..#this.capacity;
+          } */
+
+          this.elements[(this.front + this.size)..#s] = nodes;
+          this.size += s;
+          this.lock.write(false);
+          return;
+        }
+      }
     }
 
     proc ref popBack(ref hasWork: int) {
+      while true {
+        if this.lock.compareAndSwap(false, true) {
+          if (this.size > 0) {
+            hasWork = 1;
+            this.size -= 1;
+            var elt = this.elements[this.front + this.size];
+            this.lock.write(false);
+            return elt;
+          }
+          else {
+            this.lock.write(false);
+            break;
+          }
+        }
+      }
+
+      var default: eltType;
+      return default;
+    }
+
+    proc ref popBackFree(ref hasWork: int) {
       if (this.size > 0) {
         hasWork = 1;
         this.size -= 1;
@@ -42,6 +92,41 @@ module Pool_ext
 
       var default: eltType;
       return default;
+    }
+
+    proc ref popBackBulk(const m: int, const M: int) {
+      while true {
+        if this.lock.compareAndSwap(false, true) {
+          if (this.size < m) {
+            this.lock.write(false);
+            break;
+          }
+          else {
+            const poolSize = min(this.size, M);
+            this.size -= poolSize;
+            var parents: [0..#poolSize] eltType = this.elements[(this.front + this.size)..#poolSize];
+            this.lock.write(false);
+            return (poolSize, parents);
+          }
+        }
+      }
+
+      var parents: [0..-1] eltType = noinit;
+      return (0, parents);
+    }
+
+    proc ref popBackBulkFree(const m: int, const M: int) {
+      if (this.size >= 2*m) {
+        const poolSize = this.size/2; //min(this.size, M);
+        this.size -= poolSize;
+        var parents: [0..#poolSize] eltType = this.elements[(this.front + this.size)..#poolSize];
+        return (poolSize, parents);
+      } else {
+        halt("DEADCODE");
+      }
+
+      var parents: [0..-1] eltType = noinit;
+      return (0, parents);
     }
 
     proc ref popFront(ref hasWork: int) {

--- a/lib/common/Pool_ext.chpl
+++ b/lib/common/Pool_ext.chpl
@@ -17,8 +17,8 @@ module Pool_ext
     var front: int;
     var size: int;
 
-    proc init(type elemType) {
-      this.eltType = elemType;
+    proc init(type eltType) {
+      this.eltType = eltType;
       this.dom = 0..#CAPACITY;
       this.capacity = CAPACITY;
     }

--- a/lib/common/Pool_ext.chpl
+++ b/lib/common/Pool_ext.chpl
@@ -38,6 +38,8 @@ module Pool_ext
           this.lock.write(false);
           return;
         }
+
+        currentTask.yieldExecution();
       }
     }
 
@@ -59,6 +61,8 @@ module Pool_ext
           this.lock.write(false);
           return;
         }
+
+        currentTask.yieldExecution();
       }
     }
 
@@ -77,6 +81,8 @@ module Pool_ext
             break;
           }
         }
+
+        currentTask.yieldExecution();
       }
 
       var default: eltType;
@@ -109,6 +115,8 @@ module Pool_ext
             return (poolSize, parents);
           }
         }
+
+        currentTask.yieldExecution();
       }
 
       var parents: [0..-1] eltType = noinit;

--- a/lib/common/util.chpl
+++ b/lib/common/util.chpl
@@ -1,0 +1,31 @@
+module util
+{
+  param BUSY: bool = false;
+  param IDLE: bool = true;
+
+  // Take a boolean array and return false if it contains at least one "true", "true" if not
+  private inline proc _allIdle(const arr: [] atomic bool): bool
+  {
+    for elt in arr {
+      if (elt.read() == BUSY) then return false;
+    }
+
+    return true;
+  }
+
+  proc allIdle(const arr: [] atomic bool, flag: atomic bool): bool
+  {
+    if flag.read() {
+      return true; // fast exit
+    }
+    else {
+      if _allIdle(arr) {
+        flag.write(true);
+        return true;
+      }
+      else {
+        return false;
+      }
+    }
+  }
+}

--- a/lib/pfsp/Bound_johnson.chpl
+++ b/lib/pfsp/Bound_johnson.chpl
@@ -11,21 +11,21 @@ module Bound_johnson
   record lb2_bound_data
   {
     // constants
-    var nb_jobs: int;
-    var nb_machines: int;
-    var nb_machine_pairs: int;
+    var nb_jobs: int(32);
+    var nb_machines: int(32);
+    var nb_machine_pairs: int(32);
     // domains
     var ld: domain(1);
     var ad: domain(1);
     // data arrays
-    var johnson_schedules: [ld] int;
-    var lags: [ld] int;
-    var machine_pairs: [0..1] [ad] int;
-    var machine_pair_order: [ad] int;
+    var johnson_schedules: [ld] int(32);
+    var lags: [ld] int(32);
+    var machine_pairs: [0..1] [ad] int(32);
+    var machine_pair_order: [ad] int(32);
 
     proc init() {}
 
-    proc init(const jobs: int, const machines: int/*, enum lb2_variant lb2_type*/)
+    proc init(const jobs: int(32), const machines: int(32)/*, enum lb2_variant lb2_type*/)
     {
       this.nb_jobs = jobs;
       this.nb_machines = machines;
@@ -51,7 +51,7 @@ module Bound_johnson
   class WrapperClassLB2 {
     forwarding var lb2_bound: lb2_bound_data;
 
-    proc init(const jobs: int, const machines: int)
+    proc init(const jobs: int(32), const machines: int(32))
     {
       this.lb2_bound = new lb2_bound_data(jobs, machines);
     }
@@ -68,7 +68,7 @@ module Bound_johnson
       {}
       when lb2_variant.LB2_LEARN
       {
-        var c: int = 0;
+        var c: int(32) = 0;
         for i in 0..(lb2_data.nb_machines-2) {
           for j in (i+1)..(lb2_data.nb_machines-1) {
             lb2_data.machine_pairs[0][c] = i;
@@ -98,7 +98,7 @@ module Bound_johnson
   }
 
   // term q_iuv in [Lageweg'78]
-  proc fill_lags(const lb1_p_times: [] int, ref lb2_data: lb2_bound_data): void
+  proc fill_lags(const lb1_p_times: [] int(32), ref lb2_data: lb2_bound_data): void
   {
     const N = lb2_data.nb_jobs;
 
@@ -117,17 +117,17 @@ module Bound_johnson
 
   record johnson_job
   {
-    var job: int; //job-id
-    var partition: int; //in partition 0 or 1
-    var ptm1: int; //processing time on m1
-    var ptm2: int; //processing time on m2
+    var job: int(32); //job-id
+    var partition: int(32); //in partition 0 or 1
+    var ptm1: int(32); //processing time on m1
+    var ptm2: int(32); //processing time on m2
   }
 
   // Empty record serves as comparator
   record johnson_comp { }
 
   //(after partitioning) sorting jobs in ascending order with this comparator yield an optimal schedule for the associated 2-machine FSP [Johnson, S. M. (1954). Optimal two-and three-stage production schedules with setup times included.closed access Naval research logistics quarterly, 1(1), 61–68.]
-  proc johnson_comp.compare(j1, j2): int
+  proc johnson_comp.compare(j1, j2): int(32)
   {
     /* johnson_job j1 = *((johnson_job*)elem1);
     johnson_job j2 = *((johnson_job*)elem2); */
@@ -154,7 +154,7 @@ module Bound_johnson
   //  p_1i = PTM[m1][i] + lags[s][i]
   //  p_2i = PTM[m2][i] + lags[s][i]
   //using Johnson's algorithm [Johnson, S. M. (1954). Optimal two-and three-stage production schedules with setup times included.closed access Naval research logistics quarterly, 1(1), 61–68.]
-  proc fill_johnson_schedules(const lb1_p_times: [] int, ref lb2_data: lb2_bound_data): void
+  proc fill_johnson_schedules(const lb1_p_times: [] int(32), ref lb2_data: lb2_bound_data): void
   {
     const N = lb2_data.nb_jobs;
     const ref lags = lb2_data.lags;
@@ -168,7 +168,7 @@ module Bound_johnson
 
       //partition N jobs into 2 sets {j|p_1j < p_2j} and {j|p_1j >= p_2j}
       for i in 0..#N {
-        tmp[i].job = i;
+        tmp[i].job = i:int(32);
         tmp[i].ptm1 = lb1_p_times[m1*N + i] + lags[k*N + i];
         tmp[i].ptm2 = lb1_p_times[m2*N + i] + lags[k*N + i];
 
@@ -188,7 +188,7 @@ module Bound_johnson
     }
   }
 
-  proc set_flags(const permutation, const limit1: int, const limit2: int, const N: int, ref flags): void
+  proc set_flags(const permutation, const limit1: int(32), const limit2: int(32), const N: int(32), ref flags): void
   {
     for j in 0..limit1 do
       flags[permutation[j]] = 1;
@@ -197,7 +197,7 @@ module Bound_johnson
       flags[permutation[j]] = 1;
   }
 
-  inline proc compute_cmax_johnson(const lb1_p_times: [] int, const lb2_data: lb2_bound_data, const flag, ref tmp0: int, ref tmp1: int, ma0: int, ma1: int, ind: int): int
+  inline proc compute_cmax_johnson(const lb1_p_times: [] int(32), const lb2_data: lb2_bound_data, const flag, ref tmp0: int(32), ref tmp1: int(32), ma0: int(32), ma1: int(32), ind: int(32)): int(32)
   {
     const nb_jobs = lb2_data.nb_jobs;
 
@@ -218,9 +218,9 @@ module Bound_johnson
     return tmp1;
   }
 
-  proc lb_makespan(const lb1_p_times: [] int, const lb2_data: lb2_bound_data, const flag, const front, const back, const minCmax: int): int
+  proc lb_makespan(const lb1_p_times: [] int(32), const lb2_data: lb2_bound_data, const flag, const front, const back, const minCmax: int): int(32)
   {
-    var lb = 0;
+    var lb: int(32) = 0;
 
     // for all machine-pairs : O(m^2) m*(m-1)/2
     for l in 0..#lb2_data.nb_machine_pairs {
@@ -247,9 +247,9 @@ module Bound_johnson
   }
 
   //allows variable nb of machine pairs and get machine pair the realized best lb
-  proc lb_makespan_learn(const lb1_p_times: [] int, const lb2_data: lb2_bound_data, const flag: [] int, const front: [] int, const back: [] int, const minCmax: int, const nb_pairs: int, ref best_index: int): int
+  proc lb_makespan_learn(const lb1_p_times: [] int(32), const lb2_data: lb2_bound_data, const flag: [] int(32), const front: [] int(32), const back: [] int(32), const minCmax: int, const nb_pairs: int(32), ref best_index: int(32)): int(32)
   {
-    var lb = 0;
+    var lb: int(32) = 0;
 
     for l in 0..#nb_pairs {
       var i = lb2_data.machine_pair_order[l];
@@ -278,28 +278,28 @@ module Bound_johnson
     return lb;
   }
 
-  proc lb2_bound(const lb1_data: lb1_bound_data, const lb2_data: lb2_bound_data, const permutation, const limit1: int, const limit2: int, const best_cmax: int): int
+  proc lb2_bound(const lb1_data: lb1_bound_data, const lb2_data: lb2_bound_data, const permutation, const limit1: int(32), const limit2: int(32), const best_cmax: int): int(32)
   {
     /* const N = lb2_data.nb_jobs;
     const M = lb2_data.nb_machines; */
 
-    var front: NUM_MACHINES*int;
-    var back: NUM_MACHINES* int;
+    var front: NUM_MACHINES*int(32);
+    var back: NUM_MACHINES* int(32);
 
     schedule_front(lb1_data, permutation, limit1, front);
     schedule_back(lb1_data, permutation, limit2, back);
 
-    var flags: NUM_JOBS*int;
+    var flags: NUM_JOBS*int(32);
     set_flags(permutation, limit1, limit2, NUM_JOBS, flags);
 
     return lb_makespan(lb1_data.p_times, lb2_data, flags, front, back, best_cmax);
   }
 
-  proc lb2_children_bounds(const lb1_data: lb1_bound_data, const lb2_data: lb2_bound_data, const permutation, const limit1: int, const limit2: int, ref lb_begin: [] int, ref lb_end: [] int, const best_cmax: int, const direction: int): void
+  proc lb2_children_bounds(const lb1_data: lb1_bound_data, const lb2_data: lb2_bound_data, const permutation, const limit1: int(32), const limit2: int(32), ref lb_begin: [] int(32), ref lb_end: [] int(32), const best_cmax: int, const direction: int): void
   {
     const N = lb1_data.nb_jobs;
 
-    var tmp_perm: [0..#N] int;
+    var tmp_perm: [0..#N] int(32);
     for i in 0..#N do tmp_perm[i] = permutation[i];
 
     select (direction) {

--- a/lib/pfsp/Bound_simple.chpl
+++ b/lib/pfsp/Bound_simple.chpl
@@ -6,17 +6,17 @@ module Bound_simple
   record lb1_bound_data
   {
     // constants
-    var nb_jobs: int;
-    var nb_machines: int;
+    var nb_jobs: int(32);
+    var nb_machines: int(32);
     // domains
     var ptd: domain(1);
     var md: domain(1);
     // data arrays
-    var p_times: [ptd] int;
-    var min_heads: [md] int; // for each machine k, minimum time between t=0 and start of any job
-    var min_tails: [md] int; // for each machine k, minimum time between release of any job and end of processing on the last machine
+    var p_times: [ptd] int(32);
+    var min_heads: [md] int(32); // for each machine k, minimum time between t=0 and start of any job
+    var min_tails: [md] int(32); // for each machine k, minimum time between release of any job and end of processing on the last machine
 
-    proc init(const jobs: int, const machines: int)
+    proc init(const jobs: int(32), const machines: int(32))
     {
       this.nb_jobs = jobs;
       this.nb_machines = machines;
@@ -30,7 +30,7 @@ module Bound_simple
   class WrapperClassLB1 {
     forwarding var lb1_bound: lb1_bound_data;
 
-    proc init(const jobs: int, const machines: int)
+    proc init(const jobs: int(32), const machines: int(32))
     {
       this.lb1_bound = new lb1_bound_data(jobs, machines);
     }
@@ -38,7 +38,7 @@ module Bound_simple
 
   type WrapperLB1 = owned WrapperClassLB1?;
 
-  inline proc add_forward(const job: int, const p_times: [] int, const nb_jobs: int, const nb_machines: int, ref front): void
+  inline proc add_forward(const job: int(32), const p_times: [] int(32), const nb_jobs: int(32), const nb_machines: int(32), ref front): void
   {
     front[0] += p_times[job];
     for j in 1..(nb_machines-1) {
@@ -46,7 +46,7 @@ module Bound_simple
     }
   }
 
-  inline proc add_backward(const job: int, const p_times: [] int, const nb_jobs: int, const nb_machines: int, ref back): void
+  inline proc add_backward(const job: int(32), const p_times: [] int(32), const nb_jobs: int(32), const nb_machines: int(32), ref back): void
   {
     var j = nb_machines - 1;
 
@@ -56,7 +56,7 @@ module Bound_simple
     }
   }
 
-  proc schedule_front(const data: lb1_bound_data, const permutation, const limit1: int, ref front): void
+  proc schedule_front(const data: lb1_bound_data, const permutation, const limit1: int(32), ref front): void
   {
     const N = data.nb_jobs;
     const M = data.nb_machines;
@@ -73,7 +73,7 @@ module Bound_simple
     }
   }
 
-  proc schedule_back(const data: lb1_bound_data, const permutation, const limit2: int, ref back): void
+  proc schedule_back(const data: lb1_bound_data, const permutation, const limit2: int(32), ref back): void
   {
     const N = data.nb_jobs;
     const M = data.nb_machines;
@@ -90,11 +90,11 @@ module Bound_simple
     }
   }
 
-  proc eval_solution(const data: lb1_bound_data, const permutation): int
+  proc eval_solution(const data: lb1_bound_data, const permutation): int(32)
   {
     const N = data.nb_jobs;
     const M = data.nb_machines;
-    var tmp: [0..#N] int;
+    var tmp: [0..#N] int(32);
 
     for i in 0..#N {
       add_forward(permutation[i], data.p_times, N, M, tmp);
@@ -103,7 +103,7 @@ module Bound_simple
     return tmp[M-1];
   }
 
-  proc sum_unscheduled(const data: lb1_bound_data, const permutation, const limit1: int, const limit2: int, ref remain): void
+  proc sum_unscheduled(const data: lb1_bound_data, const permutation, const limit1: int(32), const limit2: int(32), ref remain): void
   {
     const N = data.nb_jobs;
     const M = data.nb_machines;
@@ -117,11 +117,11 @@ module Bound_simple
     }
   }
 
-  proc machine_bound_from_parts(const front, const back, const remain, const nb_machines: int): int
+  proc machine_bound_from_parts(const front, const back, const remain, const nb_machines: int(32)): int(32)
   {
     var tmp0 = front[0] + remain[0];
     var lb = tmp0 + back[0]; // LB on machine 0
-    var tmp1: int;
+    var tmp1: int(32);
 
     for i in 1..(nb_machines-1) {
       tmp1 = max(tmp0, front[i] + remain[i]);
@@ -132,13 +132,13 @@ module Bound_simple
     return lb;
   }
 
-  proc lb1_bound(const data: lb1_bound_data, const permutation, const limit1: int, const limit2: int): int
+  proc lb1_bound(const data: lb1_bound_data, const permutation, const limit1: int(32), const limit2: int(32)): int(32)
   {
     /* const M = data.nb_machines; */
 
-    var front: NUM_MACHINES*int;
-    var back: NUM_MACHINES*int;
-    var remain: NUM_MACHINES*int;
+    var front: NUM_MACHINES*int(32);
+    var back: NUM_MACHINES*int(32);
+    var remain: NUM_MACHINES*int(32);
 
     schedule_front(data, permutation, limit1, front);
     schedule_back(data, permutation, limit2, back);
@@ -147,14 +147,14 @@ module Bound_simple
     return machine_bound_from_parts(front, back, remain, NUM_MACHINES);
   }
 
-  proc lb1_children_bounds(const data: lb1_bound_data, const permutation, const limit1: int, const limit2: int, ref lb_begin/*, ref lb_end, prio_begin, prio_end, const direction: int*/): void
+  proc lb1_children_bounds(const data: lb1_bound_data, const permutation, const limit1: int(32), const limit2: int(32), ref lb_begin/*, ref lb_end, prio_begin, prio_end, const direction: int*/): void
   {
     /* const N = data.nb_jobs;
     const M = data.nb_machines; */
 
-    var front: NUM_MACHINES*int;
-    var back: NUM_MACHINES*int;
-    var remain: NUM_MACHINES*int;
+    var front: NUM_MACHINES*int(32);
+    var back: NUM_MACHINES*int(32);
+    var remain: NUM_MACHINES*int(32);
 
     schedule_front(data, permutation, limit1, front);
     schedule_back(data, permutation, limit2, back);
@@ -206,7 +206,7 @@ module Bound_simple
   // NB2: front, remain and back need to be set before calling this
   // NB3: also compute total idle time added to partial schedule (can be used a criterion for job ordering)
   // nOps : m*(3 add+2 max)  ---> O(m)
-  proc add_front_and_bound(const data: lb1_bound_data, const job: int, const front, const back, const remain/*, delta_idle*/): int
+  proc add_front_and_bound(const data: lb1_bound_data, const job: int(32), const front, const back, const remain/*, delta_idle*/): int(32)
   {
     const N = data.nb_jobs;
     const M = data.nb_machines;
@@ -214,7 +214,7 @@ module Bound_simple
 
     var lb   = front[0] + remain[0] + back[0];
     var tmp0 = front[0] + p_times[job];
-    var tmp1: int;
+    var tmp1: int(32);
 
     var idle = 0;
     for i in 1..(M-1) {
@@ -234,7 +234,7 @@ module Bound_simple
   }
 
   // ... same for back
-  proc add_back_and_bound(const data: lb1_bound_data, const job: int, const front, const back, const remain/*, delta_idle*/): int
+  proc add_back_and_bound(const data: lb1_bound_data, const job: int(32), const front, const back, const remain/*, delta_idle*/): int(32)
   {
     const N = data.nb_jobs;
     const M = data.nb_machines;
@@ -244,7 +244,7 @@ module Bound_simple
 
     var lb   = front[last_machine] + remain[last_machine] + back[last_machine];
     var tmp0 = back[last_machine] + p_times[last_machine*N + job];
-    var tmp1: int;
+    var tmp1: int(32);
 
     var idle = 0;
     for i in 0..#last_machine by -1 {
@@ -269,10 +269,10 @@ module Bound_simple
     const M = data.nb_machines;
     const ref p_times = data.p_times;
 
-    var tmp0, tmp1: int;
+    var tmp0, tmp1: int(32);
 
     // 1/ min start times on each machine
-    data.min_heads = max(int);
+    data.min_heads = max(int(32));
     data.min_heads[0] = 0; // per definition =0 on first machine
 
     for i in 0..#N {
@@ -280,13 +280,13 @@ module Bound_simple
 
       for k in 1..(M-1) {
         tmp1 = tmp0 + p_times[k * N + i];
-        data.min_heads[k] = min(max(int), tmp0);
+        data.min_heads[k] = min(max(int(32)), tmp0);
         tmp0 = tmp1;
       }
     }
 
     // 2/ min run-out times on each machine
-    data.min_tails = max(int);
+    data.min_tails = max(int(32));
     data.min_tails[M - 1] = 0; // per definition =0 on last machine
 
     for i in 0..#N {

--- a/lib/pfsp/PFSP_node.chpl
+++ b/lib/pfsp/PFSP_node.chpl
@@ -7,9 +7,9 @@ module PFSP_node
   config param MAX_JOBS = 20;
 
   record Node {
-    var depth: int;
-    var limit1: int; // left limit
-    var prmu: MAX_JOBS*int;
+    var depth: int(32);
+    var limit1: int(32); // left limit
+    var prmu: MAX_JOBS*int(32);
 
     // default-initializer
     proc init() {}
@@ -19,7 +19,7 @@ module PFSP_node
     {
       this.limit1 = -1;
       init this;
-      for i in 0..#jobs do this.prmu[i] = i;
+      for i in 0..#jobs do this.prmu[i] = i:int(32);
     }
 
     /*

--- a/lib/pfsp/Taillard.chpl
+++ b/lib/pfsp/Taillard.chpl
@@ -26,7 +26,7 @@ module Taillard
       1368624604 /*ta111*/, 450181436 /*ta112*/,  1927888393 /*ta113*/, 1759567256 /*ta114*/, 606425239 /*ta115*/,
       19268348 /*ta116*/,   1298201670 /*ta117*/, 2041736264 /*ta118*/, 379756761 /*ta119*/,  28837162 /*ta120*/ ];
 
-  proc taillard_get_nb_jobs(const id: int): int
+  proc taillard_get_nb_jobs(const id: int): int(32)
   {
     if (id > 110) then return 500;
     if (id > 90) then return 200;
@@ -35,7 +35,7 @@ module Taillard
     /*if(id>0)*/ return 20;
   }
 
-  proc taillard_get_nb_machines(const id: int): int
+  proc taillard_get_nb_machines(const id: int): int(32)
   {
     if (id > 110) then return 20; //500x20
     if (id > 100) then return 20; //200x20
@@ -83,7 +83,7 @@ module Taillard
     return low + (value_0_1 * (high - low + 1)): int(64);
   }
 
-  proc taillard_get_processing_times(ref ptm: [] int, const id: int): void
+  proc taillard_get_processing_times(ref ptm: [] int(32), const id: int): void
   {
     const N = taillard_get_nb_jobs(id);
     const M = taillard_get_nb_machines(id);
@@ -91,7 +91,7 @@ module Taillard
 
     for i in 0..#M {
       for j in 0..#N {
-        ptm[i*N+j] = unif(time_seed, 1, 99): int;
+        ptm[i*N+j] = unif(time_seed, 1, 99):int(32);
       }
     }
   }

--- a/pfsp_chpl.chpl
+++ b/pfsp_chpl.chpl
@@ -108,7 +108,7 @@ proc decompose_lb1(const parent: Node, ref tree_loc: uint, ref num_sol: uint,
 proc decompose_lb1_d(const parent: Node, ref tree_loc: uint, ref num_sol: uint,
   ref best: int, ref pool: SinglePool(Node))
 {
-  var lb_begin: MAX_JOBS*int;
+  var lb_begin: MAX_JOBS*int(32);
 
   lb1_children_bounds(lbound1, parent.prmu, parent.limit1, jobs, lb_begin);
 

--- a/pfsp_dist_multigpu_chpl.chpl
+++ b/pfsp_dist_multigpu_chpl.chpl
@@ -109,7 +109,7 @@ proc decompose_lb1(const lb1_data, const parent: Node, ref tree_loc: uint, ref n
 proc decompose_lb1_d(const lb1_data, const parent: Node, ref tree_loc: uint, ref num_sol: uint,
   ref best: int, ref pool: SinglePool_ext(Node))
 {
-  var lb_begin: MAX_JOBS*int;
+  var lb_begin: MAX_JOBS*int(32);
 
   lb1_children_bounds(lb1_data, parent.prmu, parent.limit1, jobs, lb_begin);
 
@@ -217,7 +217,7 @@ proc evaluate_gpu_lb1_d(const parents_d: [] Node, const size, const best, const 
     const depth = parent.depth;
     var prmu = parent.prmu;
 
-    var lb_begin: MAX_JOBS*int; //[0..#size] int = noinit;
+    var lb_begin: MAX_JOBS*int(32);
 
     lb1_children_bounds(lbound1_d, parent.prmu, parent.limit1, jobs, lb_begin);
 
@@ -266,7 +266,7 @@ proc evaluate_gpu(const parents_d: [] Node, const size, const best, const lbound
 }
 
 // Generate children nodes (evaluated by GPU) on CPU.
-proc generate_children(const ref parents: [] Node, const size: int, const ref bounds: [] int,
+proc generate_children(const ref parents: [] Node, const size: int, const ref bounds: [] int(32),
   ref exploredTree: uint, ref exploredSol: uint, ref best: int, ref pool: SinglePool_ext(Node))
 {
   for i in 0..#size {
@@ -443,11 +443,11 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
             something like that.
           */
           const numBounds = jobs * poolSize;
-          var bounds: [0..#numBounds] int = noinit;
+          var bounds: [0..#numBounds] int(32) = noinit;
 
           on device {
             const parents_d = parents; // host-to-device
-            var bounds_d: [0..#numBounds] int = noinit;
+            var bounds_d: [0..#numBounds] int(32) = noinit;
             evaluate_gpu(parents_d, numBounds, best_l, lbound1_d, lbound2_d, bounds_d);
             bounds = bounds_d; // device-to-host
           }

--- a/pfsp_dist_multigpu_chpl.chpl
+++ b/pfsp_dist_multigpu_chpl.chpl
@@ -185,10 +185,8 @@ proc decompose(const lb1_data, const lb2_data, const parent: Node, ref tree_loc:
 }
 
 // Evaluate a bulk of parent nodes on GPU using lb1.
-proc evaluate_gpu_lb1(const parents_d: [] Node, const size, const lbound1_d)
+proc evaluate_gpu_lb1(const parents_d: [] Node, const size, const lbound1_d, ref bounds_d)
 {
-  var bounds: [0..#size] int = 0;
-
   @assertOnGpu
   foreach threadId in 0..#size {
     const parentId = threadId / jobs;
@@ -199,12 +197,10 @@ proc evaluate_gpu_lb1(const parents_d: [] Node, const size, const lbound1_d)
 
     if (k >= parent.limit1+1) {
       prmu[depth] <=> prmu[k];
-      bounds[threadId] = lb1_bound(lbound1_d, prmu, parent.limit1+1, jobs);
+      bounds_d[threadId] = lb1_bound(lbound1_d, prmu, parent.limit1+1, jobs);
       prmu[depth] <=> prmu[k];
     }
   }
-
-  return bounds;
 }
 
 /*
@@ -213,10 +209,8 @@ proc evaluate_gpu_lb1(const parents_d: [] Node, const size, const lbound1_d)
   to the other lower bounds.
 */
 // Evaluate a bulk of parent nodes on GPU using lb1_d.
-proc evaluate_gpu_lb1_d(const parents_d: [] Node, const size, const best, const lbound1_d)
+proc evaluate_gpu_lb1_d(const parents_d: [] Node, const size, const best, const lbound1_d, ref bounds_d)
 {
-  var bounds: [0..#size] int = noinit;
-
   @assertOnGpu
   foreach parentId in 0..#(size/jobs) {
     var parent = parents_d[parentId];
@@ -230,19 +224,15 @@ proc evaluate_gpu_lb1_d(const parents_d: [] Node, const size, const best, const 
     for k in 0..#jobs {
       if (k >= parent.limit1+1) {
         const job = parent.prmu[k];
-        bounds[parentId*jobs+k] = lb_begin[job];
+        bounds_d[parentId*jobs+k] = lb_begin[job];
       }
     }
   }
-
-  return bounds;
 }
 
 // Evaluate a bulk of parent nodes on GPU using lb2.
-proc evaluate_gpu_lb2(const parents_d: [] Node, const size, const best, const lbound1_d, const lbound2_d)
+proc evaluate_gpu_lb2(const parents_d: [] Node, const size, const best, const lbound1_d, const lbound2_d, ref bounds_d)
 {
-  var bounds: [0..#size] int = noinit;
-
   @assertOnGpu
   foreach threadId in 0..#size {
     const parentId = threadId / jobs;
@@ -253,26 +243,24 @@ proc evaluate_gpu_lb2(const parents_d: [] Node, const size, const best, const lb
 
     if (k >= parent.limit1+1) {
       prmu[depth] <=> prmu[k];
-      bounds[threadId] = lb2_bound(lbound1_d, lbound2_d, prmu, parent.limit1+1, jobs, best);
+      bounds_d[threadId] = lb2_bound(lbound1_d, lbound2_d, prmu, parent.limit1+1, jobs, best);
       prmu[depth] <=> prmu[k];
     }
   }
-
-  return bounds;
 }
 
 // Evaluate a bulk of parent nodes on GPU.
-proc evaluate_gpu(const parents_d: [] Node, const size, const best, const lbound1_d, const lbound2_d)
+proc evaluate_gpu(const parents_d: [] Node, const size, const best, const lbound1_d, const lbound2_d, ref bounds_d)
 {
   select lb {
     when 0 {
-      return evaluate_gpu_lb1_d(parents_d, size, best, lbound1_d!.lb1_bound);
+      evaluate_gpu_lb1_d(parents_d, size, best, lbound1_d!.lb1_bound, bounds_d);
     }
     when 1 {
-      return evaluate_gpu_lb1(parents_d, size, lbound1_d!.lb1_bound);
+      evaluate_gpu_lb1(parents_d, size, lbound1_d!.lb1_bound, bounds_d);
     }
     otherwise { // 2
-      return evaluate_gpu_lb2(parents_d, size, best, lbound1_d!.lb1_bound, lbound2_d!.lb2_bound);
+      evaluate_gpu_lb2(parents_d, size, best, lbound1_d!.lb1_bound, lbound2_d!.lb2_bound, bounds_d);
     }
   }
 }
@@ -457,7 +445,9 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
 
           on gpu {
             const parents_d = parents; // host-to-device
-            bounds = evaluate_gpu(parents_d, numBounds, best_l, lbound1_d, lbound2_d);
+            var bounds_d: [0..#numBounds] int = noinit;
+            evaluate_gpu(parents_d, numBounds, best_l, lbound1_d, lbound2_d, bounds_d);
+            bounds = bounds_d; // device-to-host
           }
 
           /*

--- a/pfsp_dist_multigpu_chpl.chpl
+++ b/pfsp_dist_multigpu_chpl.chpl
@@ -381,8 +381,10 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
     pool_lloc.front = 0;
     pool_lloc.size = 0;
 
-    coforall (gpuID, gpu) in zip(0..#D, here.gpus) with (ref pool,
-      ref eachExploredTree, ref eachExploredSol, ref eachBest) {
+    coforall gpuID in 0..#D with (ref pool, ref eachExploredTree, ref eachExploredSol,
+      ref eachBest) {
+
+      const device = here.gpus[gpuID];
 
       var tree, sol: uint;
       var pool_loc = new SinglePool_ext(Node);
@@ -408,7 +410,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
       var lbound1_d: lbound1.type;
       var lbound2_d: lbound2.type;
 
-      on gpu {
+      on device {
         lbound1_d = new WrapperLB1(jobs, machines);
         lbound1_d!.lb1_bound.p_times   = lbound1!.lb1_bound.p_times;
         lbound1_d!.lb1_bound.min_heads = lbound1!.lb1_bound.min_heads;
@@ -443,7 +445,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
           const numBounds = jobs * poolSize;
           var bounds: [0..#numBounds] int = noinit;
 
-          on gpu {
+          on device {
             const parents_d = parents; // host-to-device
             var bounds_d: [0..#numBounds] int = noinit;
             evaluate_gpu(parents_d, numBounds, best_l, lbound1_d, lbound2_d, bounds_d);

--- a/pfsp_gpu_chpl.chpl
+++ b/pfsp_gpu_chpl.chpl
@@ -117,7 +117,7 @@ proc decompose_lb1(const parent: Node, ref tree_loc: uint, ref num_sol: uint,
 proc decompose_lb1_d(const parent: Node, ref tree_loc: uint, ref num_sol: uint,
   ref best: int, ref pool: SinglePool(Node))
 {
-  var lb_begin: MAX_JOBS*int;
+  var lb_begin: MAX_JOBS*int(32);
 
   lb1_children_bounds(lbound1!.lb1_bound, parent.prmu, parent.limit1, jobs, lb_begin);
 
@@ -225,7 +225,7 @@ proc evaluate_gpu_lb1_d(const parents_d: [] Node, const size, const best, const 
     const depth = parent.depth;
     var prmu = parent.prmu;
 
-    var lb_begin: MAX_JOBS*int; //[0..#size] int = noinit;
+    var lb_begin: MAX_JOBS*int(32);
 
     lb1_children_bounds(lbound1_d!.lb1_bound, parent.prmu, parent.limit1, jobs, lb_begin);
 
@@ -274,7 +274,7 @@ proc evaluate_gpu(const parents_d: [] Node, const size, const best, const lbound
 }
 
 // Generate children nodes (evaluated by GPU) on CPU.
-proc generate_children(const ref parents: [] Node, const size: int, const ref bounds: [] int,
+proc generate_children(const ref parents: [] Node, const size: int, const ref bounds: [] int(32),
   ref exploredTree: uint, ref exploredSol: uint, ref best: int, ref pool: SinglePool(Node))
 {
   for i in 0..#size {
@@ -380,11 +380,11 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
         something like that.
       */
       const numBounds = jobs * poolSize;
-      var bounds: [0..#numBounds] int = noinit;
+      var bounds: [0..#numBounds] int(32) = noinit;
 
       on device {
         const parents_d = parents; // host-to-device
-        var bounds_d: [0..#numBounds] int = noinit;
+        var bounds_d: [0..#numBounds] int(32) = noinit;
         evaluate_gpu(parents_d, numBounds, best, lbound1_d, lbound2_d, bounds_d);
         bounds = bounds_d; // device-to-host
       }

--- a/pfsp_gpu_chpl.chpl
+++ b/pfsp_gpu_chpl.chpl
@@ -309,6 +309,8 @@ proc generate_children(const ref parents: [] Node, const size: int, const ref bo
 // Single-GPU PFSP search.
 proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint, ref elapsedTime: real)
 {
+  const device = here.gpus[0];
+
   var best: int = initUB;
 
   var root = new Node(jobs);
@@ -347,7 +349,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
   var lbound1_d: lbound1.type;
   var lbound2_d: lbound2.type;
 
-  on here.gpus[0] {
+  on device {
     lbound1_d = new WrapperLB1(jobs, machines);
     lbound1_d!.lb1_bound.p_times   = lbound1!.lb1_bound.p_times;
     lbound1_d!.lb1_bound.min_heads = lbound1!.lb1_bound.min_heads;
@@ -380,7 +382,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
       const numBounds = jobs * poolSize;
       var bounds: [0..#numBounds] int = noinit;
 
-      on here.gpus[0] {
+      on device {
         const parents_d = parents; // host-to-device
         var bounds_d: [0..#numBounds] int = noinit;
         evaluate_gpu(parents_d, numBounds, best, lbound1_d, lbound2_d, bounds_d);

--- a/pfsp_multigpu_chpl.chpl
+++ b/pfsp_multigpu_chpl.chpl
@@ -187,10 +187,8 @@ proc decompose(const lb1_data, const lb2_data, const parent: Node, ref tree_loc:
 }
 
 // Evaluate a bulk of parent nodes on GPU using lb1.
-proc evaluate_gpu_lb1(const parents_d: [] Node, const size, const lbound1_d)
+proc evaluate_gpu_lb1(const parents_d: [] Node, const size, const lbound1_d, ref bounds_d)
 {
-  var bounds: [0..#size] int = 0;
-
   @assertOnGpu
   foreach threadId in 0..#size {
     const parentId = threadId / jobs;
@@ -201,12 +199,10 @@ proc evaluate_gpu_lb1(const parents_d: [] Node, const size, const lbound1_d)
 
     if (k >= parent.limit1+1) {
       prmu[depth] <=> prmu[k];
-      bounds[threadId] = lb1_bound(lbound1_d, prmu, parent.limit1+1, jobs);
+      bounds_d[threadId] = lb1_bound(lbound1_d, prmu, parent.limit1+1, jobs);
       prmu[depth] <=> prmu[k];
     }
   }
-
-  return bounds;
 }
 
 /*
@@ -215,10 +211,8 @@ proc evaluate_gpu_lb1(const parents_d: [] Node, const size, const lbound1_d)
   to the other lower bounds.
 */
 // Evaluate a bulk of parent nodes on GPU using lb1_d.
-proc evaluate_gpu_lb1_d(const parents_d: [] Node, const size, const best, const lbound1_d)
+proc evaluate_gpu_lb1_d(const parents_d: [] Node, const size, const best, const lbound1_d, ref bounds_d)
 {
-  var bounds: [0..#size] int = noinit;
-
   @assertOnGpu
   foreach parentId in 0..#(size/jobs) {
     var parent = parents_d[parentId];
@@ -232,19 +226,15 @@ proc evaluate_gpu_lb1_d(const parents_d: [] Node, const size, const best, const 
     for k in 0..#jobs {
       if (k >= parent.limit1+1) {
         const job = parent.prmu[k];
-        bounds[parentId*jobs+k] = lb_begin[job];
+        bounds_d[parentId*jobs+k] = lb_begin[job];
       }
     }
   }
-
-  return bounds;
 }
 
 // Evaluate a bulk of parent nodes on GPU using lb2.
-proc evaluate_gpu_lb2(const parents_d: [] Node, const size, const best, const lbound1_d, const lbound2_d)
+proc evaluate_gpu_lb2(const parents_d: [] Node, const size, const best, const lbound1_d, const lbound2_d, ref bounds_d)
 {
-  var bounds: [0..#size] int = noinit;
-
   @assertOnGpu
   foreach threadId in 0..#size {
     const parentId = threadId / jobs;
@@ -255,26 +245,24 @@ proc evaluate_gpu_lb2(const parents_d: [] Node, const size, const best, const lb
 
     if (k >= parent.limit1+1) {
       prmu[depth] <=> prmu[k];
-      bounds[threadId] = lb2_bound(lbound1_d, lbound2_d, prmu, parent.limit1+1, jobs, best);
+      bounds_d[threadId] = lb2_bound(lbound1_d, lbound2_d, prmu, parent.limit1+1, jobs, best);
       prmu[depth] <=> prmu[k];
     }
   }
-
-  return bounds;
 }
 
 // Evaluate a bulk of parent nodes on GPU.
-proc evaluate_gpu(const parents_d: [] Node, const size, const best, const lbound1_d, const lbound2_d)
+proc evaluate_gpu(const parents_d: [] Node, const size, const best, const lbound1_d, const lbound2_d, ref bounds_d)
 {
   select lb {
     when 0 {
-      return evaluate_gpu_lb1_d(parents_d, size, best, lbound1_d!.lb1_bound);
+      evaluate_gpu_lb1_d(parents_d, size, best, lbound1_d!.lb1_bound, bounds_d);
     }
     when 1 {
-      return evaluate_gpu_lb1(parents_d, size, lbound1_d!.lb1_bound);
+      evaluate_gpu_lb1(parents_d, size, lbound1_d!.lb1_bound, bounds_d);
     }
     otherwise { // 2
-      return evaluate_gpu_lb2(parents_d, size, best, lbound1_d!.lb1_bound, lbound2_d!.lb2_bound);
+      evaluate_gpu_lb2(parents_d, size, best, lbound1_d!.lb1_bound, lbound2_d!.lb2_bound, bounds_d);
     }
   }
 }
@@ -450,7 +438,9 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
 
         on gpu {
           const parents_d = parents; // host-to-device
-          bounds = evaluate_gpu(parents_d, numBounds, best_l, lbound1_d, lbound2_d);
+          var bounds_d: [0..#numBounds] int = noinit;
+          evaluate_gpu(parents_d, numBounds, best_l, lbound1_d, lbound2_d, bounds_d);
+          bounds = bounds_d; // device-to-host
         }
 
         /*

--- a/pfsp_multigpu_chpl.chpl
+++ b/pfsp_multigpu_chpl.chpl
@@ -175,13 +175,13 @@ proc decompose(const lb1_data, const lb2_data, const parent: Node, ref tree_loc:
 {
   select lb {
     when 0 {
-      decompose_lb1_d(lb1_data!.lb1_bound, parent, tree_loc, num_sol, best, pool);
+      decompose_lb1_d(lb1_data, parent, tree_loc, num_sol, best, pool);
     }
     when 1 {
-      decompose_lb1(lb1_data!.lb1_bound, parent, tree_loc, num_sol, best, pool);
+      decompose_lb1(lb1_data, parent, tree_loc, num_sol, best, pool);
     }
     otherwise { // 2
-      decompose_lb2(lb1_data!.lb1_bound, lb2_data!.lb2_bound, parent, tree_loc, num_sol, best, pool);
+      decompose_lb2(lb1_data, lb2_data, parent, tree_loc, num_sol, best, pool);
     }
   }
 }
@@ -321,21 +321,21 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
   */
   timer.start();
 
-  var lbound1_p = new WrapperLB1(jobs, machines); //lb1_bound_data(jobs, machines);
-  taillard_get_processing_times(lbound1_p!.lb1_bound.p_times, inst);
-  fill_min_heads_tails(lbound1_p!.lb1_bound);
+  var lbound1 = new lb1_bound_data(jobs, machines);
+  taillard_get_processing_times(lbound1.p_times, inst);
+  fill_min_heads_tails(lbound1);
 
-  var lbound2_p = new WrapperLB2(jobs, machines);
-  fill_machine_pairs(lbound2_p!.lb2_bound/*, LB2_FULL*/);
-  fill_lags(lbound1_p!.lb1_bound.p_times, lbound2_p!.lb2_bound);
-  fill_johnson_schedules(lbound1_p!.lb1_bound.p_times, lbound2_p!.lb2_bound);
+  var lbound2 = new lb2_bound_data(jobs, machines);
+  fill_machine_pairs(lbound2/*, LB2_FULL*/);
+  fill_lags(lbound1.p_times, lbound2);
+  fill_johnson_schedules(lbound1.p_times, lbound2);
 
   while (pool.size < D*m) {
     var hasWork = 0;
     var parent = pool.popFront(hasWork);
     if !hasWork then break;
 
-    decompose(lbound1_p, lbound2_p, parent, exploredTree, exploredSol, best, pool);
+    decompose(lbound1, lbound2, parent, exploredTree, exploredSol, best, pool);
   }
   timer.stop();
   const res1 = (timer.elapsed(), exploredTree, exploredSol);
@@ -383,29 +383,20 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
       pool_loc.size += l-c;
     }
 
-    var lbound1 = new WrapperLB1(jobs, machines); //lb1_bound_data(jobs, machines);
-    taillard_get_processing_times(lbound1!.lb1_bound.p_times, inst);
-    fill_min_heads_tails(lbound1!.lb1_bound);
-
-    var lbound2 = new WrapperLB2(jobs, machines);
-    fill_machine_pairs(lbound2!.lb2_bound/*, LB2_FULL*/);
-    fill_lags(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
-    fill_johnson_schedules(lbound1!.lb1_bound.p_times, lbound2!.lb2_bound);
-
-    var lbound1_d: lbound1.type;
-    var lbound2_d: lbound2.type;
+    var lbound1_d: WrapperLB1;
+    var lbound2_d: WrapperLB2;
 
     on device {
       lbound1_d = new WrapperLB1(jobs, machines);
-      lbound1_d!.lb1_bound.p_times   = lbound1!.lb1_bound.p_times;
-      lbound1_d!.lb1_bound.min_heads = lbound1!.lb1_bound.min_heads;
-      lbound1_d!.lb1_bound.min_tails = lbound1!.lb1_bound.min_tails;
+      lbound1_d!.lb1_bound.p_times   = lbound1.p_times;
+      lbound1_d!.lb1_bound.min_heads = lbound1.min_heads;
+      lbound1_d!.lb1_bound.min_tails = lbound1.min_tails;
 
       lbound2_d = new WrapperLB2(jobs, machines);
-      lbound2_d!.lb2_bound.johnson_schedules  = lbound2!.lb2_bound.johnson_schedules;
-      lbound2_d!.lb2_bound.lags               = lbound2!.lb2_bound.lags;
-      lbound2_d!.lb2_bound.machine_pairs      = lbound2!.lb2_bound.machine_pairs;
-      lbound2_d!.lb2_bound.machine_pair_order = lbound2!.lb2_bound.machine_pair_order;
+      lbound2_d!.lb2_bound.johnson_schedules  = lbound2.johnson_schedules;
+      lbound2_d!.lb2_bound.lags               = lbound2.lags;
+      lbound2_d!.lb2_bound.machine_pairs      = lbound2.machine_pairs;
+      lbound2_d!.lb2_bound.machine_pair_order = lbound2.machine_pair_order;
     }
 
     while true {
@@ -455,7 +446,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
         var steal = false;
         const victims = permute(0..#D);
 
-        while (tries < D && steal == false) {
+        label WS0 while (tries < D && steal == false) {
           const victimID = victims[tries];
 
           if (victimID != gpuID) { // if not me
@@ -463,10 +454,10 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
             nSteal += 1;
             var nn = 0;
 
-            while (nn < 10) {
+            label WS1 while (nn < 10) {
               if victim.lock.compareAndSwap(false, true) { // get the lock
                 const size = victim.size;
-                /* writeln("victim size = ", size); */
+
                 if (size >= 2*m) {
                   var (hasWork, p) = victim.popBackBulkFree(m, M);
                   if (hasWork == 0) {
@@ -482,15 +473,15 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
                   steal = true;
                   nSSteal += 1;
                   victim.lock.write(false); // reset lock
-                  break;
+                  break WS0;
                 }
-                else {
-                  victim.lock.write(false); // reset lock
-                  break;
-                }
-              } else {
-                nn += 1;
+
+                victim.lock.write(false); // reset lock
+                break WS1;
               }
+
+              nn += 1;
+              currentTask.yieldExecution();
             }
           }
           tries += 1;
@@ -552,7 +543,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
     var parent = pool.popBack(hasWork);
     if !hasWork then break;
 
-    decompose(lbound1_p, lbound2_p, parent, exploredTree, exploredSol, best, pool);
+    decompose(lbound1, lbound2, parent, exploredTree, exploredSol, best, pool);
   }
   timer.stop();
   elapsedTime = timer.elapsed();

--- a/pfsp_multigpu_chpl.chpl
+++ b/pfsp_multigpu_chpl.chpl
@@ -363,9 +363,10 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
 
   var multiPool: [0..#D] SinglePool_ext(Node);
 
-  coforall (gpuID, gpu) in zip(0..#D, here.gpus) with (ref pool,
-    ref eachExploredTree, ref eachExploredSol, ref eachBest,
-    ref eachTaskState, ref multiPool) {
+  coforall gpuID in 0..#D with (ref pool, ref eachExploredTree, ref eachExploredSol,
+    ref eachBest, ref eachTaskState, ref multiPool) {
+
+    const device = here.gpus[gpuID];
 
     var nSteal, nSSteal: int;
 
@@ -394,7 +395,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
     var lbound1_d: lbound1.type;
     var lbound2_d: lbound2.type;
 
-    on gpu {
+    on device {
       lbound1_d = new WrapperLB1(jobs, machines);
       lbound1_d!.lb1_bound.p_times   = lbound1!.lb1_bound.p_times;
       lbound1_d!.lb1_bound.min_heads = lbound1!.lb1_bound.min_heads;
@@ -436,7 +437,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
         const numBounds = jobs * poolSize;
         var bounds: [0..#numBounds] int = noinit;
 
-        on gpu {
+        on device {
           const parents_d = parents; // host-to-device
           var bounds_d: [0..#numBounds] int = noinit;
           evaluate_gpu(parents_d, numBounds, best_l, lbound1_d, lbound2_d, bounds_d);

--- a/pfsp_multigpu_chpl.chpl
+++ b/pfsp_multigpu_chpl.chpl
@@ -111,7 +111,7 @@ proc decompose_lb1(const lb1_data, const parent: Node, ref tree_loc: uint, ref n
 proc decompose_lb1_d(const lb1_data, const parent: Node, ref tree_loc: uint, ref num_sol: uint,
   ref best: int, ref pool: SinglePool_ext(Node))
 {
-  var lb_begin: MAX_JOBS*int;
+  var lb_begin: MAX_JOBS*int(32);
 
   lb1_children_bounds(lb1_data, parent.prmu, parent.limit1, jobs, lb_begin);
 
@@ -219,7 +219,7 @@ proc evaluate_gpu_lb1_d(const parents_d: [] Node, const size, const best, const 
     const depth = parent.depth;
     var prmu = parent.prmu;
 
-    var lb_begin: MAX_JOBS*int; //[0..#size] int = noinit;
+    var lb_begin: MAX_JOBS*int(32);
 
     lb1_children_bounds(lbound1_d, parent.prmu, parent.limit1, jobs, lb_begin);
 
@@ -268,7 +268,7 @@ proc evaluate_gpu(const parents_d: [] Node, const size, const best, const lbound
 }
 
 // Generate children nodes (evaluated by GPU) on CPU.
-proc generate_children(const ref parents: [] Node, const size: int, const ref bounds: [] int,
+proc generate_children(const ref parents: [] Node, const size: int, const ref bounds: [] int(32),
   ref exploredTree: uint, ref exploredSol: uint, ref best: int, ref pool: SinglePool_ext(Node))
 {
   for i in 0..#size {
@@ -435,11 +435,11 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
           something like that.
         */
         const numBounds = jobs * poolSize;
-        var bounds: [0..#numBounds] int = noinit;
+        var bounds: [0..#numBounds] int(32) = noinit;
 
         on device {
           const parents_d = parents; // host-to-device
-          var bounds_d: [0..#numBounds] int = noinit;
+          var bounds_d: [0..#numBounds] int(32) = noinit;
           evaluate_gpu(parents_d, numBounds, best_l, lbound1_d, lbound2_d, bounds_d);
           bounds = bounds_d; // device-to-host
         }

--- a/pfsp_multigpu_chpl.chpl
+++ b/pfsp_multigpu_chpl.chpl
@@ -372,12 +372,14 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
   pool.front = 0;
   pool.size = 0;
 
+  var multiPool: [0..#D] SinglePool_ext(Node);
+
   coforall (gpuID, gpu) in zip(0..#D, here.gpus) with (ref pool,
     ref eachExploredTree, ref eachExploredSol, ref eachBest,
-    ref eachTaskState) {
+    ref eachTaskState, ref multiPool) {
 
     var tree, sol: uint;
-    var pool_loc = new SinglePool_ext(Node);
+    ref pool_loc = multiPool[gpuID];
     var best_l = best;
     var taskState: bool = BUSY;
 


### PR DESCRIPTION
This PR implements a dynamic work stealing mechanism for the Chapel multi-GPU code. The latter is necessary to achieve good scaling efficiency tackling the irregular Branch-and-Bound method. While there, the PR also provides some performance optimizations, e.g. using `int(32)` instead of `int(64)`.