### PR TITLE
Fixing segmentation fault on certain instances (ta022) multiGPU version Chapel.

### DIFF
--- a/lib/common/Pool_ext.chpl
+++ b/lib/common/Pool_ext.chpl
@@ -49,7 +49,7 @@ module Pool_ext
       while true {
         if this.lock.compareAndSwap(false, true) {
           if (this.front + this.size >= this.capacity) {
-            this.capacity *= exp2(ceil(log2((this.front + this.size + s) / this.capacity)));
+            this.capacity *= exp2(ceil(log2( ((this.front + this.size + s) / this.capacity):real )));
             this.dom = 0..#this.capacity;
           }
 

--- a/lib/common/Pool_ext.chpl
+++ b/lib/common/Pool_ext.chpl
@@ -49,7 +49,7 @@ module Pool_ext
       while true {
         if this.lock.compareAndSwap(false, true) {
           if (this.front + this.size >= this.capacity) {
-            this.capacity *= 2*ceil(log2((this.front + this.size + s) / this.capacity));
+            this.capacity *= exp2(ceil(log2((this.front + this.size + s) / this.capacity)));
             this.dom = 0..#this.capacity;
           }
 

--- a/lib/common/Pool_ext.chpl
+++ b/lib/common/Pool_ext.chpl
@@ -49,7 +49,7 @@ module Pool_ext
       while true {
         if this.lock.compareAndSwap(false, true) {
           if (this.front + this.size >= this.capacity) {
-            this.capacity += (s+this.front+1);
+            this.capacity *= 2*ceil(log2((this.front + this.size + s) / this.capacity));
             this.dom = 0..#this.capacity;
           }
 

--- a/lib/common/Pool_ext.chpl
+++ b/lib/common/Pool_ext.chpl
@@ -49,7 +49,7 @@ module Pool_ext
       while true {
         if this.lock.compareAndSwap(false, true) {
           if (this.front + this.size >= this.capacity) {
-            this.capacity *= 2;
+            this.capacity += (s+this.front+1);
             this.dom = 0..#this.capacity;
           }
 


### PR DESCRIPTION
Pool capacity might not be big enough depending on the size of s in function pushBackBulk. This should fix the problem for highly irregular instances.