### PR TITLE
Improve pool implementations in Chapel

### DIFF
--- a/lib/common/Pool.chpl
+++ b/lib/common/Pool.chpl
@@ -7,7 +7,7 @@ module Pool
   strategies.
   *******************************************************************************/
 
-  config param CAPACITY = 1024;
+  config param INITIAL_CAPACITY = 1024;
 
   record SinglePool {
     type eltType;
@@ -19,15 +19,15 @@ module Pool
 
     proc init(type eltType) {
       this.eltType = eltType;
-      this.dom = 0..#CAPACITY;
-      this.capacity = CAPACITY;
+      this.dom = {0..#INITIAL_CAPACITY};
+      this.capacity = INITIAL_CAPACITY;
     }
 
     // Insertion to the end of the deque.
     proc ref pushBack(node: eltType) {
       if (this.front + this.size >= this.capacity) {
         this.capacity *= 2;
-        this.dom = 0..#this.capacity;
+        this.dom = {0..#this.capacity};
       }
 
       this.elements[this.front + this.size] = node;

--- a/lib/common/Pool.chpl
+++ b/lib/common/Pool.chpl
@@ -1,10 +1,10 @@
 module Pool
 {
   /*******************************************************************************
-  Implementation of a dynamic-sized single pool data structure.
-  Its initial capacity is 1024, and we reallocate a new container with double
-  the capacity when it is full. Since we perform only DFS, it only supports
-  'pushBack' and 'popBack' operations.
+  Dynamic-sized single-pool data structure. Its initial capacity is 1024, and we
+  reallocate a new container with double the capacity when it is full. The pool
+  supports operations from both ends, allowing breadth-first and depth-first search
+  strategies.
   *******************************************************************************/
 
   config param CAPACITY = 1024;
@@ -23,6 +23,7 @@ module Pool
       this.capacity = CAPACITY;
     }
 
+    // Insertion to the end of the deque.
     proc ref pushBack(node: eltType) {
       if (this.front + this.size >= this.capacity) {
         this.capacity *= 2;
@@ -33,6 +34,7 @@ module Pool
       this.size += 1;
     }
 
+    // Removal from the end of the deque.
     proc ref popBack(ref hasWork: int) {
       if (this.size > 0) {
         hasWork = 1;
@@ -44,6 +46,7 @@ module Pool
       return default;
     }
 
+    // Removal from the front of the deque.
     proc ref popFront(ref hasWork: int) {
       if (this.size > 0) {
         hasWork = 1;

--- a/lib/common/Pool_par.chpl
+++ b/lib/common/Pool_par.chpl
@@ -148,5 +148,20 @@ module Pool_par
       var default: eltType;
       return default;
     }
+
+    proc ref popFrontBulkFree(const m: int, const M: int) {
+      if (this.size >= 2*m) {
+        const poolSize = this.size/2; //min(this.size, M);
+        this.size -= poolSize;
+        var parents: [0..#poolSize] eltType = this.elements[this.front..#poolSize];
+        this.front += poolSize;
+        return (poolSize, parents);
+      } else {
+        halt("DEADCODE");
+      }
+
+      var parents: [0..-1] eltType = noinit;
+      return (0, parents);
+    }
   }
 }

--- a/lib/common/Pool_par.chpl
+++ b/lib/common/Pool_par.chpl
@@ -131,8 +131,6 @@ module Pool_par
         this.size -= poolSize;
         var parents: [0..#poolSize] eltType = this.elements[(this.front + this.size)..#poolSize];
         return (poolSize, parents);
-      } else {
-        halt("DEADCODE");
       }
 
       var parents: [0..-1] eltType = noinit;
@@ -161,8 +159,6 @@ module Pool_par
         var parents: [0..#poolSize] eltType = this.elements[this.front..#poolSize];
         this.front += poolSize;
         return (poolSize, parents);
-      } else {
-        halt("DEADCODE");
       }
 
       var parents: [0..-1] eltType = noinit;

--- a/lib/common/Pool_par.chpl
+++ b/lib/common/Pool_par.chpl
@@ -1,5 +1,7 @@
 module Pool_par
 {
+  use Math;
+
   /*******************************************************************************
   Implementation of a dynamic-sized single pool data structure.
   Its initial capacity is 1024, and we reallocate a new container with double
@@ -7,7 +9,7 @@ module Pool_par
   'pushBack' and 'popBack' operations.
   *******************************************************************************/
 
-  config param CAPACITY = 1024000;
+  config param CAPACITY = 1024;
 
   record SinglePool_par {
     type eltType;
@@ -48,13 +50,10 @@ module Pool_par
 
       while true {
         if this.lock.compareAndSwap(false, true) {
-          /*
-            TODO: Implement dynamic-size mechanism in that case.
-          */
-          /* if (this.front + this.size >= this.capacity) {
-            this.capacity *= 2;
+          if (this.front + this.size + s >= this.capacity) {
+            this.capacity *= 2**ceil(log2((this.front + this.size + s) / this.capacity:real)):int;
             this.dom = 0..#this.capacity;
-          } */
+          }
 
           this.elements[(this.front + this.size)..#s] = nodes;
           this.size += s;

--- a/lib/common/Pool_par.chpl
+++ b/lib/common/Pool_par.chpl
@@ -3,10 +3,8 @@ module Pool_par
   use Math;
 
   /*******************************************************************************
-  Implementation of a dynamic-sized single pool data structure.
-  Its initial capacity is 1024, and we reallocate a new container with double
-  the capacity when it is full. Since we perform only DFS, it only supports
-  'pushBack' and 'popBack' operations.
+  Extension of the "Pool" data structure ensuring parallel-safety and supporting
+  bulk operations.
   *******************************************************************************/
 
   config param CAPACITY = 1024;
@@ -27,6 +25,7 @@ module Pool_par
       this.lock = false;
     }
 
+    // Parallel-safe insertion to the end of the deque.
     proc ref pushBack(node: eltType) {
       while true {
         if this.lock.compareAndSwap(false, true) {
@@ -45,6 +44,7 @@ module Pool_par
       }
     }
 
+    // Parallel-safe bulk insertion to the end of the deque.
     proc ref pushBackBulk(nodes: [] eltType) {
       const s = nodes.size;
 
@@ -65,6 +65,7 @@ module Pool_par
       }
     }
 
+    // Parallel-safe removal from the end of the deque.
     proc ref popBack(ref hasWork: int) {
       while true {
         if this.lock.compareAndSwap(false, true) {
@@ -88,6 +89,7 @@ module Pool_par
       return default;
     }
 
+    // Removal from the end of the deque. Parallel-safety is not guaranteed.
     proc ref popBackFree(ref hasWork: int) {
       if (this.size > 0) {
         hasWork = 1;
@@ -99,6 +101,7 @@ module Pool_par
       return default;
     }
 
+    // Parallel-safe bulk removal from the end of the deque.
     proc ref popBackBulk(const m: int, const M: int, ref parents) {
       while true {
         if this.lock.compareAndSwap(false, true) {
@@ -121,6 +124,7 @@ module Pool_par
       return 0;
     }
 
+    // Bulk removal from the end of the deque. Parallel-safety is not guaranteed.
     proc ref popBackBulkFree(const m: int, const M: int) {
       if (this.size >= 2*m) {
         const poolSize = this.size/2; //min(this.size, M);
@@ -135,7 +139,8 @@ module Pool_par
       return (0, parents);
     }
 
-    proc ref popFront(ref hasWork: int) {
+    // Removal from the front of the deque. Parallel-safety is not guaranteed.
+    proc ref popFrontFree(ref hasWork: int) {
       if (this.size > 0) {
         hasWork = 1;
         const elt = this.elements[this.front];
@@ -148,6 +153,7 @@ module Pool_par
       return default;
     }
 
+    // Bulk removal from the front of the deque. Parallel-safety is not guaranteed.
     proc ref popFrontBulkFree(const m: int, const M: int) {
       if (this.size >= 2*m) {
         const poolSize = this.size/2; //min(this.size, M);

--- a/lib/common/Pool_par.chpl
+++ b/lib/common/Pool_par.chpl
@@ -7,7 +7,7 @@ module Pool_par
   bulk operations.
   *******************************************************************************/
 
-  config param CAPACITY = 1024;
+  config param INITIAL_CAPACITY = 1024;
 
   record SinglePool_par {
     type eltType;
@@ -20,8 +20,8 @@ module Pool_par
 
     proc init(type eltType) {
       this.eltType = eltType;
-      this.dom = {0..#CAPACITY};
-      this.capacity = CAPACITY;
+      this.dom = {0..#INITIAL_CAPACITY};
+      this.capacity = INITIAL_CAPACITY;
       this.lock = false;
     }
 
@@ -31,7 +31,7 @@ module Pool_par
         if this.lock.compareAndSwap(false, true) {
           if (this.front + this.size >= this.capacity) {
             this.capacity *= 2;
-            this.dom = 0..#this.capacity;
+            this.dom = {0..#this.capacity};
           }
 
           this.elements[this.front + this.size] = node;
@@ -52,7 +52,7 @@ module Pool_par
         if this.lock.compareAndSwap(false, true) {
           if (this.front + this.size + s >= this.capacity) {
             this.capacity *= 2**ceil(log2((this.front + this.size + s) / this.capacity:real)):int;
-            this.dom = 0..#this.capacity;
+            this.dom = {0..#this.capacity};
           }
 
           this.elements[(this.front + this.size)..#s] = nodes;

--- a/pfsp_multigpu_chpl.chpl
+++ b/pfsp_multigpu_chpl.chpl
@@ -472,7 +472,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
                 const size = victim.size;
 
                 if (size >= 2*m) {
-                  var (hasWork, p) = victim.popBackBulkFree(m, M);
+                  var (hasWork, p) = victim.popFrontBulkFree(m, M);
                   if (hasWork == 0) {
                     victim.lock.write(false); // reset lock
                     halt("DEADCODE in work stealing");

--- a/pfsp_multigpu_chpl.chpl
+++ b/pfsp_multigpu_chpl.chpl
@@ -339,7 +339,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
 
   while (pool.size < D*m) {
     var hasWork = 0;
-    var parent = pool.popFront(hasWork);
+    var parent = pool.popFrontFree(hasWork);
     if !hasWork then break;
 
     decompose(lbound1, lbound2, parent, exploredTree, exploredSol, best, pool);
@@ -553,7 +553,7 @@ proc pfsp_search(ref optimum: int, ref exploredTree: uint, ref exploredSol: uint
   timer.start();
   while true {
     var hasWork = 0;
-    var parent = pool.popBack(hasWork);
+    var parent = pool.popBackFree(hasWork);
     if !hasWork then break;
 
     decompose(lbound1, lbound2, parent, exploredTree, exploredSol, best, pool);


### PR DESCRIPTION
This PR provides the following improvements:
- implement `popFrontBulkFree`, and use it instead of `popBackBulkFree` in WS
- fix the capacity extension in `pushBackBulk` (previously marked as a TODO)
- rename `popFront` to `popFrontFree` to make clear the non parallel-safety
- update documentation
- minor improvements