### PR TITLE
Refactor makefile for PFSP baseline

### DIFF
--- a/baselines/pfsp/README.md
+++ b/baselines/pfsp/README.md
@@ -1,0 +1,7 @@
+# Building code
+
+The provided `makefile` builds all CUDA-based codes as well as HIP-based ones (using the ROCm/HIP `hipify-perl` tool).
+
+The `SYSTEM` command-line option can be set to `{g5k, lumi}` to handle manually the system specific library paths etc. It defaults to `g5k`. For the moment, the following systems are supported:
+- the [Grid5000](https://www.grid5000.fr/w/Grid5000:Home) large-scale testbed;
+- the [LUMI](https://docs.lumi-supercomputer.eu/) pre-exascale supercomputer.

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -38,6 +38,9 @@ all: $(EXECUTABLES)
 %.o: %.c
 	$(C_COMPILER) $(C_COMMON_OPTS) -c -fopenmp $< -o $@ -I/share/compilers/nvidia/cuda/12.0/include -I/usr/local/cuda-11.2/targets/x86_64-linux/include/
 
+pfsp_dist_multigpu_cuda.o: pfsp_dist_multigpu_cuda.c
+	$(MPI_COMPILER) $(C_COMMON_OPTS) -c -fopenmp $< -o $@ -I/share/compilers/nvidia/cuda/12.0/include -I/usr/local/cuda-11.2/targets/x86_64-linux/include/
+
 # Pattern rule for CUDA source files
 %.o: %.cu
 	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) -c $< -o $@
@@ -56,7 +59,10 @@ pfsp_multigpu_cuda.out: pfsp_multigpu_cuda.o lib/c_taillard.o lib/c_bound_simple
 
 #Build executable CUDA+OpenMP+MPI
 pfsp_dist_multigpu_cuda.out: pfsp_dist_multigpu_cuda.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/evaluate.o lib/PFSP_node.o lib/Pool_ext.o lib/Auxiliary.o
-	$(C_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart -L/usr/local/cuda-11.2/targets/x86_64-linux/lib/
+	$(MPI_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart -L/usr/local/cuda-11.2/targets/x86_64-linux/lib/
+
+#############################################################
+#############################################################
 
 # Pattern rule for HIP source files
 	hipify-perl pfsp_gpu_cuda.c > pfsp_gpu_cuda.c.hip

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -1,7 +1,8 @@
 SHELL := /bin/bash
 
 # Compilers & common options
-C_COMPILER    := mpicc #gcc
+C_COMPILER    := gcc
+MPI_COMPILER  := mpicc
 CUDA_COMPILER := nvcc
 HIP_COMPILER  := hipcc
 

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -12,7 +12,10 @@ HIP_COMMON_OPTS  := $(C_COMMON_OPTS) -offload-arch=gfx906
 
 HIP_PATCH_G5K    := DEVICE_LIB_PATH=/opt/rocm-4.5.0/amdgcn/bitcode/
 
-MPI_LIBPATH_G5K  := -I/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi -I/usr/lib/x86_64-linux-gnu/openmpi/include -L/usr/lib/x86_64-linux-gnu/openmpi/lib
+MPI_INCLUDE_G5K  := -I/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi -I/usr/lib/x86_64-linux-gnu/openmpi/include
+MPI_LIB_G5K      := -L/usr/lib/x86_64-linux-gnu/openmpi/lib
+CUDA_INCLUDE_G5K := -I/share/compilers/nvidia/cuda/12.0/include -I/usr/local/cuda-11.2/targets/x86_64-linux/include
+CUDA_LIB_G5K     := -L/usr/local/cuda-11.2/targets/x86_64-linux/lib
 
 # Source files
 C_SOURCES    := lib/c_taillard.c lib/c_bound_simple.c lib/c_bound_johnson.c lib/PFSP_node.c lib/Pool.c lib/Pool_ext.c lib/Auxiliary.c pfsp_c.c pfsp_gpu_cuda.c pfsp_multigpu_cuda.c pfsp_dist_multigpu_cuda.c
@@ -36,10 +39,10 @@ all: $(EXECUTABLES)
 
 # Pattern rule for C source files
 %.o: %.c
-	$(C_COMPILER) $(C_COMMON_OPTS) -c -fopenmp $< -o $@ -I/share/compilers/nvidia/cuda/12.0/include -I/usr/local/cuda-11.2/targets/x86_64-linux/include/
+	$(C_COMPILER) $(C_COMMON_OPTS) -c -fopenmp $< -o $@ $(CUDA_INCLUDE_G5K)
 
 pfsp_dist_multigpu_cuda.o: pfsp_dist_multigpu_cuda.c
-	$(MPI_COMPILER) $(C_COMMON_OPTS) -c -fopenmp $< -o $@ -I/share/compilers/nvidia/cuda/12.0/include -I/usr/local/cuda-11.2/targets/x86_64-linux/include/
+	$(MPI_COMPILER) $(C_COMMON_OPTS) -c -fopenmp $< -o $@ $(CUDA_INCLUDE_G5K)
 
 # Pattern rule for CUDA source files
 %.o: %.cu
@@ -51,15 +54,15 @@ pfsp_c.out: pfsp_c.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o
 
 # Build executable for CUDA
 pfsp_gpu_cuda.out: pfsp_gpu_cuda.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/evaluate.o lib/PFSP_node.o lib/Pool.o
-	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@ -lm -lcudart -L/usr/local/cuda-11.2/targets/x86_64-linux/lib/
+	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@ -lm -lcudart $(CUDA_LIB_G5K)
 
 #Build executable for CUDA+OpenMP
 pfsp_multigpu_cuda.out: pfsp_multigpu_cuda.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/evaluate.o lib/PFSP_node.o lib/Pool_ext.o lib/Auxiliary.o
-	$(C_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart -L/usr/local/cuda-11.2/targets/x86_64-linux/lib/
+	$(C_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_LIB_G5K)
 
 #Build executable CUDA+OpenMP+MPI
 pfsp_dist_multigpu_cuda.out: pfsp_dist_multigpu_cuda.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/evaluate.o lib/PFSP_node.o lib/Pool_ext.o lib/Auxiliary.o
-	$(MPI_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart -L/usr/local/cuda-11.2/targets/x86_64-linux/lib/
+	$(MPI_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_LIB_G5K)
 
 #############################################################
 #############################################################
@@ -82,10 +85,10 @@ pfsp_multigpu_hip.out: pfsp_multigpu_hip.o lib/c_taillard.o lib/c_bound_simple.o
 
 # Pattern rule for hybrid MPI+OpenMP+HIP source files
 	hipify-perl pfsp_dist_multigpu_cuda.c > pfsp_dist_multigpu_cuda.c.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_LIBPATH_G5K) -fopenmp -c pfsp_dist_multigpu_cuda.c.hip -o pfsp_dist_multigpu_hip.o
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE_G5K) $(MPI_LIB_G5K) -fopenmp -c pfsp_dist_multigpu_cuda.c.hip -o pfsp_dist_multigpu_hip.o
 
 pfsp_dist_multigpu_hip.out: pfsp_dist_multigpu_hip.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/PFSP_node.o lib/Pool_ext.o lib/Auxiliary.o lib/evaluate_hip.o
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_LIBPATH_G5K) -lmpi_cxx -lmpi -lopen-pal -fopenmp $^ -o $@
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE_G5K) $(MPI_LIB_G5K) -lmpi_cxx -lmpi -lopen-pal -fopenmp $^ -o $@
 
 # Utilities
 .PHONY: clean

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -17,9 +17,11 @@ MPI_LIB_G5K      := -L/usr/lib/x86_64-linux-gnu/openmpi/lib
 CUDA_INCLUDE_G5K := -I/share/compilers/nvidia/cuda/12.0/include -I/usr/local/cuda-11.2/targets/x86_64-linux/include
 CUDA_LIB_G5K     := -L/usr/local/cuda-11.2/targets/x86_64-linux/lib
 
+LIBPATH := lib
+
 # Source files
-C_SOURCES    := lib/c_taillard.c lib/c_bound_simple.c lib/c_bound_johnson.c lib/PFSP_node.c lib/Pool.c lib/Pool_ext.c lib/Auxiliary.c pfsp_c.c pfsp_gpu_cuda.c pfsp_multigpu_cuda.c pfsp_dist_multigpu_cuda.c
-CUDA_SOURCES := lib/evaluate.cu lib/c_bounds_gpu.cu
+C_SOURCES    := $(LIBPATH)/c_taillard.c $(LIBPATH)/c_bound_simple.c $(LIBPATH)/c_bound_johnson.c $(LIBPATH)/PFSP_node.c $(LIBPATH)/Pool.c $(LIBPATH)/Pool_ext.c $(LIBPATH)/Auxiliary.c pfsp_c.c pfsp_gpu_cuda.c pfsp_multigpu_cuda.c pfsp_dist_multigpu_cuda.c
+CUDA_SOURCES := $(LIBPATH)/evaluate.cu $(LIBPATH)/c_bounds_gpu.cu
 HIP_SOURCES  :=
 
 # Object files
@@ -49,19 +51,19 @@ pfsp_dist_multigpu_cuda.o: pfsp_dist_multigpu_cuda.c
 	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) -c $< -o $@
 
 # Build executable for CPU only
-pfsp_c.out: pfsp_c.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/PFSP_node.o lib/Pool.o
+pfsp_c.out: pfsp_c.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o
 	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@
 
 # Build executable for CUDA
-pfsp_gpu_cuda.out: pfsp_gpu_cuda.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/evaluate.o lib/PFSP_node.o lib/Pool.o
+pfsp_gpu_cuda.out: pfsp_gpu_cuda.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o
 	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@ -lm -lcudart $(CUDA_LIB_G5K)
 
 #Build executable for CUDA+OpenMP
-pfsp_multigpu_cuda.out: pfsp_multigpu_cuda.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/evaluate.o lib/PFSP_node.o lib/Pool_ext.o lib/Auxiliary.o
+pfsp_multigpu_cuda.out: pfsp_multigpu_cuda.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o
 	$(C_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_LIB_G5K)
 
 #Build executable CUDA+OpenMP+MPI
-pfsp_dist_multigpu_cuda.out: pfsp_dist_multigpu_cuda.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/evaluate.o lib/PFSP_node.o lib/Pool_ext.o lib/Auxiliary.o
+pfsp_dist_multigpu_cuda.out: pfsp_dist_multigpu_cuda.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o
 	$(MPI_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_LIB_G5K)
 
 #############################################################
@@ -69,25 +71,25 @@ pfsp_dist_multigpu_cuda.out: pfsp_dist_multigpu_cuda.o lib/c_taillard.o lib/c_bo
 
 # Pattern rule for HIP source files
 	hipify-perl pfsp_gpu_cuda.c > pfsp_gpu_cuda.c.hip
-	hipify-perl lib/evaluate.cu > lib/evaluate.cu.hip
+	hipify-perl $(LIBPATH)/evaluate.cu > $(LIBPATH)/evaluate.cu.hip
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c pfsp_gpu_cuda.c.hip -o pfsp_gpu_hip.o
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c lib/evaluate.cu.hip -o lib/evaluate_hip.o
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $(LIBPATH)/evaluate.cu.hip -o $(LIBPATH)/evaluate_hip.o
 
-pfsp_gpu_hip.out: pfsp_gpu_hip.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/PFSP_node.o lib/Pool.o lib/evaluate_hip.o
+pfsp_gpu_hip.out: pfsp_gpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o $(LIBPATH)/evaluate_hip.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $^ -o $@
 
 # Pattern rule for hybrid OpenMP+HIP source files
 	hipify-perl pfsp_multigpu_cuda.c > pfsp_multigpu_cuda.c.hip
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp -c pfsp_multigpu_cuda.c.hip -o pfsp_multigpu_hip.o
 
-pfsp_multigpu_hip.out: pfsp_multigpu_hip.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/PFSP_node.o lib/Pool_ext.o lib/Auxiliary.o lib/evaluate_hip.o
+pfsp_multigpu_hip.out: pfsp_multigpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o $(LIBPATH)/evaluate_hip.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp $^ -o $@
 
 # Pattern rule for hybrid MPI+OpenMP+HIP source files
 	hipify-perl pfsp_dist_multigpu_cuda.c > pfsp_dist_multigpu_cuda.c.hip
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE_G5K) $(MPI_LIB_G5K) -fopenmp -c pfsp_dist_multigpu_cuda.c.hip -o pfsp_dist_multigpu_hip.o
 
-pfsp_dist_multigpu_hip.out: pfsp_dist_multigpu_hip.o lib/c_taillard.o lib/c_bound_simple.o lib/c_bound_johnson.o lib/PFSP_node.o lib/Pool_ext.o lib/Auxiliary.o lib/evaluate_hip.o
+pfsp_dist_multigpu_hip.out: pfsp_dist_multigpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o $(LIBPATH)/evaluate_hip.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE_G5K) $(MPI_LIB_G5K) -lmpi_cxx -lmpi -lopen-pal -fopenmp $^ -o $@
 
 # Utilities

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -10,7 +10,7 @@ HIP_COMPILER  := hipcc
 
 C_COMMON_OPTS    := -O3 -Wall -g
 CUDA_COMMON_OPTS := -O3 -arch=sm_86 # TODO: adapt SM automatically, if possible
-HIP_COMMON_OPTS  := $(C_COMMON_OPTS) -offload-arch=gfx906
+HIP_COMMON_OPTS  := $(C_COMMON_OPTS) --offload-arch=gfx906
 
 LIBPATH := lib
 

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -1,6 +1,8 @@
 SHELL := /bin/bash
 
-# Compilers & common options
+SYSTEM ?= g5k
+
+# Compilers and common options
 C_COMPILER    := gcc
 MPI_COMPILER  := mpicc
 CUDA_COMPILER := nvcc
@@ -10,14 +12,21 @@ C_COMMON_OPTS    := -O3 -Wall -g
 CUDA_COMMON_OPTS := -O3 -arch=sm_86 # TODO: adapt SM automatically, if possible
 HIP_COMMON_OPTS  := $(C_COMMON_OPTS) -offload-arch=gfx906
 
-HIP_PATCH_G5K    := DEVICE_LIB_PATH=/opt/rocm-4.5.0/amdgcn/bitcode/
-
-MPI_INCLUDE_G5K  := -I/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi -I/usr/lib/x86_64-linux-gnu/openmpi/include
-MPI_LIB_G5K      := -L/usr/lib/x86_64-linux-gnu/openmpi/lib
-CUDA_INCLUDE_G5K := -I/share/compilers/nvidia/cuda/12.0/include -I/usr/local/cuda-11.2/targets/x86_64-linux/include
-CUDA_LIB_G5K     := -L/usr/local/cuda-11.2/targets/x86_64-linux/lib
-
 LIBPATH := lib
+
+# Platform-specific flags and libraries
+ifeq ($(SYSTEM), g5k)
+  # HIP compiler patch
+  HIP_COMPILER  := DEVICE_LIB_PATH=/opt/rocm-4.5.0/amdgcn/bitcode/ hipcc
+  # library paths
+  MPI_INCLUDE  := -I/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi -I/usr/lib/x86_64-linux-gnu/openmpi/include
+  MPI_LIB      := -L/usr/lib/x86_64-linux-gnu/openmpi/lib
+  CUDA_INCLUDE := -I/share/compilers/nvidia/cuda/12.0/include -I/usr/local/cuda-11.2/targets/x86_64-linux/include
+  CUDA_LIB     := -L/usr/local/cuda-11.2/targets/x86_64-linux/lib
+else ifeq ($(SYSTEM), lumi)
+  # library paths
+  MPI_INCLUDE  := -I/opt/cray/pe/mpich/8.1.27/ofi/cray/14.0/include
+endif
 
 # Source files
 # C_SOURCES        := pfsp_c.c pfsp_gpu_cuda.c pfsp_multigpu_cuda.c pfsp_dist_multigpu_cuda.c
@@ -49,45 +58,45 @@ pfsp_c.out: pfsp_c.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPA
 
 # Build executable for single-GPU in C+CUDA
 pfsp_gpu_cuda.out: pfsp_gpu_cuda.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o
-	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@ -lm -lcudart $(CUDA_INCLUDE_G5K) $(CUDA_LIB_G5K)
+	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@ -lm -lcudart $(CUDA_INCLUDE) $(CUDA_LIB)
 
 # Build executable for multi-GPU in C+OpenMP+CUDA
 pfsp_multigpu_cuda.out: pfsp_multigpu_cuda.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o
-	$(C_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_INCLUDE_G5K) $(CUDA_LIB_G5K)
+	$(C_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_INCLUDE) $(CUDA_LIB)
 
 # Build executable for distributed multi-GPU in C+MPI+OpenMP+CUDA
 pfsp_dist_multigpu_cuda.out: pfsp_dist_multigpu_cuda.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o
-	$(MPI_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_INCLUDE_G5K) $(CUDA_LIB_G5K)
+	$(MPI_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_INCLUDE) $(CUDA_LIB)
 
 $(LIBPATH)/evaluate_hip.o: $(LIBPATH)/evaluate.cu
 	hipify-perl $< > $<.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
+	$(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
 
 # TODO: find an elegant way to avoid intermediate *_hip.o object files
 
 # Build executable for single-GPU in C+HIP
 pfsp_gpu_hip.o: pfsp_gpu_cuda.c
 	hipify-perl $< > $<.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
+	$(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
 
 pfsp_gpu_hip.out: pfsp_gpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o $(LIBPATH)/evaluate_hip.o
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $^ -o $@
+	$(HIP_COMPILER) $(HIP_COMMON_OPTS) $^ -o $@
 
 # Build executable for multi-GPU in C+OpenMP+HIP
 pfsp_multigpu_hip.o: pfsp_multigpu_cuda.c
 	hipify-perl $< > $<.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp -c $<.hip -o $@
+	$(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp -c $<.hip -o $@
 
 pfsp_multigpu_hip.out: pfsp_multigpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o $(LIBPATH)/evaluate_hip.o
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp $^ -o $@
+	$(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp $^ -o $@
 
 # Build executable for distributed multi-GPU in C+MPI+OpenMP+HIP
 pfsp_dist_multigpu_hip.o: pfsp_dist_multigpu_cuda.c
 	hipify-perl $< > $<.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE_G5K) $(MPI_LIB_G5K) -fopenmp -c $<.hip -o $@
+	$(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE) $(MPI_LIB) -fopenmp -c $<.hip -o $@
 
 pfsp_dist_multigpu_hip.out: pfsp_dist_multigpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o $(LIBPATH)/evaluate_hip.o
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE_G5K) $(MPI_LIB_G5K) -lmpi_cxx -lmpi -lopen-pal -fopenmp $^ -o $@
+	$(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE) $(MPI_LIB) -lmpi_cxx -lmpi -lopen-pal -fopenmp $^ -o $@
 
 # Utilities
 .PHONY: clean

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -25,7 +25,6 @@ C_LIB_SOURCES    := $(LIBPATH)/c_taillard.c $(LIBPATH)/c_bound_simple.c $(LIBPAT
 CUDA_LIB_SOURCES := $(LIBPATH)/evaluate.cu $(LIBPATH)/c_bounds_gpu.cu
 
 # Object files
-C_OBJECTS        := $(C_SOURCES:.c=.o)
 C_LIB_OBJECTS    := $(C_LIB_SOURCES:.c=.o)
 CUDA_LIB_OBJECTS := $(CUDA_LIB_SOURCES:.cu=.o)
 HIP_OBJECTS      := $(HIP_SOURCES:hip.cu=hip.o)
@@ -36,19 +35,6 @@ EXECUTABLES := pfsp_c.out pfsp_gpu_cuda.out pfsp_multigpu_cuda.out pfsp_dist_mul
 # Build codes
 all: $(EXECUTABLES)
 
-# Pattern rule for C source files
-pfsp_c.o: pfsp_c.c
-	$(C_COMPILER) $(C_COMMON_OPTS) -c $< -o $@
-
-pfsp_gpu_cuda.o: pfsp_gpu_cuda.c
-	$(C_COMPILER) $(C_COMMON_OPTS) -c $< -o $@ $(CUDA_INCLUDE_G5K)
-
-pfsp_multigpu_cuda.o: pfsp_multigpu_cuda.c
-	$(C_COMPILER) $(C_COMMON_OPTS) -c -fopenmp $< -o $@ $(CUDA_INCLUDE_G5K)
-
-pfsp_dist_multigpu_cuda.o: pfsp_dist_multigpu_cuda.c
-	$(MPI_COMPILER) $(C_COMMON_OPTS) -c -fopenmp $< -o $@ $(CUDA_INCLUDE_G5K)
-
 # Pattern rule for C library source files
 $(LIBPATH)/%.o: $(LIBPATH)/%.c
 	$(C_COMPILER) $(C_COMMON_OPTS) -c $< -o $@
@@ -58,20 +44,20 @@ $(LIBPATH)/%.o: $(LIBPATH)/%.cu
 	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) -c $< -o $@
 
 # Build executable for CPU only
-pfsp_c.out: pfsp_c.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o
+pfsp_c.out: pfsp_c.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o
 	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@
 
 # Build executable for CUDA
-pfsp_gpu_cuda.out: pfsp_gpu_cuda.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o
-	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@ -lm -lcudart $(CUDA_LIB_G5K)
+pfsp_gpu_cuda.out: pfsp_gpu_cuda.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o
+	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@ -lm -lcudart $(CUDA_INCLUDE_G5K) $(CUDA_LIB_G5K)
 
 #Build executable for CUDA+OpenMP
-pfsp_multigpu_cuda.out: pfsp_multigpu_cuda.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o
-	$(C_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_LIB_G5K)
+pfsp_multigpu_cuda.out: pfsp_multigpu_cuda.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o
+	$(C_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_INCLUDE_G5K) $(CUDA_LIB_G5K)
 
 #Build executable CUDA+OpenMP+MPI
-pfsp_dist_multigpu_cuda.out: pfsp_dist_multigpu_cuda.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o
-	$(MPI_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_LIB_G5K)
+pfsp_dist_multigpu_cuda.out: pfsp_dist_multigpu_cuda.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o
+	$(MPI_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_INCLUDE_G5K) $(CUDA_LIB_G5K)
 
 #############################################################
 #############################################################

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -62,16 +62,20 @@ pfsp_dist_multigpu_cuda.out: pfsp_dist_multigpu_cuda.c $(LIBPATH)/c_taillard.o $
 #############################################################
 #############################################################
 
-# Pattern rule for HIP source files
-	hipify-perl pfsp_gpu_cuda.c > pfsp_gpu_cuda.c.hip
+evaluate_hip.o: evaluate.cu
 	hipify-perl $(LIBPATH)/evaluate.cu > $(LIBPATH)/evaluate.cu.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c pfsp_gpu_cuda.c.hip -o pfsp_gpu_hip.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $(LIBPATH)/evaluate.cu.hip -o $(LIBPATH)/evaluate_hip.o
+
+# Pattern rule for HIP source files
+pfsp_gpu_hip.o: pfsp_gpu_cuda.c
+	hipify-perl pfsp_gpu_cuda.c > pfsp_gpu_cuda.c.hip
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c pfsp_gpu_cuda.c.hip -o pfsp_gpu_hip.o
 
 pfsp_gpu_hip.out: pfsp_gpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o $(LIBPATH)/evaluate_hip.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $^ -o $@
 
 # Pattern rule for hybrid OpenMP+HIP source files
+pfsp_multigpu_hip.o: pfsp_multigpu_cuda.c
 	hipify-perl pfsp_multigpu_cuda.c > pfsp_multigpu_cuda.c.hip
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp -c pfsp_multigpu_cuda.c.hip -o pfsp_multigpu_hip.o
 
@@ -79,6 +83,7 @@ pfsp_multigpu_hip.out: pfsp_multigpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp $^ -o $@
 
 # Pattern rule for hybrid MPI+OpenMP+HIP source files
+pfsp_dist_multigpu_hip.o: pfsp_dist_multigpu_cuda.c
 	hipify-perl pfsp_dist_multigpu_cuda.c > pfsp_dist_multigpu_cuda.c.hip
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE_G5K) $(MPI_LIB_G5K) -fopenmp -c pfsp_dist_multigpu_cuda.c.hip -o pfsp_dist_multigpu_hip.o
 

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -39,34 +39,33 @@ all: $(EXECUTABLES)
 $(LIBPATH)/%.o: $(LIBPATH)/%.c
 	$(C_COMPILER) $(C_COMMON_OPTS) -c $< -o $@
 
-# Pattern rule for CUDA source files
+# Pattern rule for CUDA library source files
 $(LIBPATH)/%.o: $(LIBPATH)/%.cu
 	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) -c $< -o $@
 
-# Build executable for CPU only
+# Build executable for sequential in C
 pfsp_c.out: pfsp_c.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o
 	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@
 
-# Build executable for CUDA
+# Build executable for single-GPU in C+CUDA
 pfsp_gpu_cuda.out: pfsp_gpu_cuda.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o
 	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@ -lm -lcudart $(CUDA_INCLUDE_G5K) $(CUDA_LIB_G5K)
 
-#Build executable for CUDA+OpenMP
+# Build executable for multi-GPU in C+OpenMP+CUDA
 pfsp_multigpu_cuda.out: pfsp_multigpu_cuda.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o
 	$(C_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_INCLUDE_G5K) $(CUDA_LIB_G5K)
 
-#Build executable CUDA+OpenMP+MPI
+# Build executable for distributed multi-GPU in C+MPI+OpenMP+CUDA
 pfsp_dist_multigpu_cuda.out: pfsp_dist_multigpu_cuda.c $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/evaluate.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o
 	$(MPI_COMPILER) $(C_COMMON_OPTS) -fopenmp $^ -o $@ -lm -lcudart $(CUDA_INCLUDE_G5K) $(CUDA_LIB_G5K)
-
-#############################################################
-#############################################################
 
 $(LIBPATH)/evaluate_hip.o: $(LIBPATH)/evaluate.cu
 	hipify-perl $< > $<.hip
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
 
-# Pattern rule for HIP source files
+# TODO: find an elegant way to avoid intermediate *_hip.o object files
+
+# Build executable for single-GPU in C+HIP
 pfsp_gpu_hip.o: pfsp_gpu_cuda.c
 	hipify-perl $< > $<.hip
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
@@ -74,7 +73,7 @@ pfsp_gpu_hip.o: pfsp_gpu_cuda.c
 pfsp_gpu_hip.out: pfsp_gpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o $(LIBPATH)/evaluate_hip.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $^ -o $@
 
-# Pattern rule for hybrid OpenMP+HIP source files
+# Build executable for multi-GPU in C+OpenMP+HIP
 pfsp_multigpu_hip.o: pfsp_multigpu_cuda.c
 	hipify-perl $< > $<.hip
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp -c $<.hip -o $@
@@ -82,7 +81,7 @@ pfsp_multigpu_hip.o: pfsp_multigpu_cuda.c
 pfsp_multigpu_hip.out: pfsp_multigpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o $(LIBPATH)/evaluate_hip.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp $^ -o $@
 
-# Pattern rule for hybrid MPI+OpenMP+HIP source files
+# Build executable for distributed multi-GPU in C+MPI+OpenMP+HIP
 pfsp_dist_multigpu_hip.o: pfsp_dist_multigpu_cuda.c
 	hipify-perl $< > $<.hip
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE_G5K) $(MPI_LIB_G5K) -fopenmp -c $<.hip -o $@

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -20,14 +20,14 @@ CUDA_LIB_G5K     := -L/usr/local/cuda-11.2/targets/x86_64-linux/lib
 LIBPATH := lib
 
 # Source files
-C_SOURCES        := pfsp_c.c pfsp_gpu_cuda.c pfsp_multigpu_cuda.c pfsp_dist_multigpu_cuda.c
-C_LIB_SOURCES    := $(LIBPATH)/c_taillard.c $(LIBPATH)/c_bound_simple.c $(LIBPATH)/c_bound_johnson.c $(LIBPATH)/PFSP_node.c $(LIBPATH)/Pool.c $(LIBPATH)/Pool_ext.c $(LIBPATH)/Auxiliary.c
-CUDA_LIB_SOURCES := $(LIBPATH)/evaluate.cu $(LIBPATH)/c_bounds_gpu.cu
+# C_SOURCES        := pfsp_c.c pfsp_gpu_cuda.c pfsp_multigpu_cuda.c pfsp_dist_multigpu_cuda.c
+# C_LIB_SOURCES    := $(LIBPATH)/c_taillard.c $(LIBPATH)/c_bound_simple.c $(LIBPATH)/c_bound_johnson.c $(LIBPATH)/PFSP_node.c $(LIBPATH)/Pool.c $(LIBPATH)/Pool_ext.c $(LIBPATH)/Auxiliary.c
+# CUDA_LIB_SOURCES := $(LIBPATH)/evaluate.cu $(LIBPATH)/c_bounds_gpu.cu
 
 # Object files
-C_LIB_OBJECTS    := $(C_LIB_SOURCES:.c=.o)
-CUDA_LIB_OBJECTS := $(CUDA_LIB_SOURCES:.cu=.o)
-HIP_OBJECTS      := $(HIP_SOURCES:hip.cu=hip.o)
+# C_LIB_OBJECTS    := $(C_LIB_SOURCES:.c=.o)
+# CUDA_LIB_OBJECTS := $(CUDA_LIB_SOURCES:.cu=.o)
+# HIP_OBJECTS      := $(HIP_SOURCES:hip.cu=hip.o)
 
 # Executable names
 EXECUTABLES := pfsp_c.out pfsp_gpu_cuda.out pfsp_multigpu_cuda.out pfsp_dist_multigpu_cuda.out pfsp_gpu_hip.out pfsp_multigpu_hip.out pfsp_dist_multigpu_hip.out
@@ -94,4 +94,4 @@ pfsp_dist_multigpu_hip.out: pfsp_dist_multigpu_hip.o $(LIBPATH)/c_taillard.o $(L
 .PHONY: clean
 
 clean:
-	rm -f $(C_OBJECTS) $(CUDA_OBJECTS) *.o *.out *.dat $(HIP_OBJECTS) *.hip
+	rm -f *.out *.o *.hip $(LIBPATH)/*.o $(LIBPATH)/*.hip

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -37,7 +37,13 @@ EXECUTABLES := pfsp_c.out pfsp_gpu_cuda.out pfsp_multigpu_cuda.out pfsp_dist_mul
 all: $(EXECUTABLES)
 
 # Pattern rule for C source files
-%.o: %.c
+pfsp_c.o: pfsp_c.c
+	$(C_COMPILER) $(C_COMMON_OPTS) -c $< -o $@
+
+pfsp_gpu_cuda.o: pfsp_gpu_cuda.c
+	$(C_COMPILER) $(C_COMMON_OPTS) -c $< -o $@ $(CUDA_INCLUDE_G5K)
+
+pfsp_multigpu_cuda.o: pfsp_multigpu_cuda.c
 	$(C_COMPILER) $(C_COMMON_OPTS) -c -fopenmp $< -o $@ $(CUDA_INCLUDE_G5K)
 
 pfsp_dist_multigpu_cuda.o: pfsp_dist_multigpu_cuda.c

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -62,30 +62,30 @@ pfsp_dist_multigpu_cuda.out: pfsp_dist_multigpu_cuda.c $(LIBPATH)/c_taillard.o $
 #############################################################
 #############################################################
 
-evaluate_hip.o: evaluate.cu
-	hipify-perl $(LIBPATH)/evaluate.cu > $(LIBPATH)/evaluate.cu.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $(LIBPATH)/evaluate.cu.hip -o $(LIBPATH)/evaluate_hip.o
+$(LIBPATH)/evaluate_hip.o: $(LIBPATH)/evaluate.cu
+	hipify-perl $< > $<.hip
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
 
 # Pattern rule for HIP source files
 pfsp_gpu_hip.o: pfsp_gpu_cuda.c
-	hipify-perl pfsp_gpu_cuda.c > pfsp_gpu_cuda.c.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c pfsp_gpu_cuda.c.hip -o pfsp_gpu_hip.o
+	hipify-perl $< > $<.hip
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
 
 pfsp_gpu_hip.out: pfsp_gpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool.o $(LIBPATH)/evaluate_hip.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $^ -o $@
 
 # Pattern rule for hybrid OpenMP+HIP source files
 pfsp_multigpu_hip.o: pfsp_multigpu_cuda.c
-	hipify-perl pfsp_multigpu_cuda.c > pfsp_multigpu_cuda.c.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp -c pfsp_multigpu_cuda.c.hip -o pfsp_multigpu_hip.o
+	hipify-perl $< > $<.hip
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp -c $<.hip -o $@
 
 pfsp_multigpu_hip.out: pfsp_multigpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o $(LIBPATH)/evaluate_hip.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp $^ -o $@
 
 # Pattern rule for hybrid MPI+OpenMP+HIP source files
 pfsp_dist_multigpu_hip.o: pfsp_dist_multigpu_cuda.c
-	hipify-perl pfsp_dist_multigpu_cuda.c > pfsp_dist_multigpu_cuda.c.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE_G5K) $(MPI_LIB_G5K) -fopenmp -c pfsp_dist_multigpu_cuda.c.hip -o pfsp_dist_multigpu_hip.o
+	hipify-perl $< > $<.hip
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE_G5K) $(MPI_LIB_G5K) -fopenmp -c $<.hip -o $@
 
 pfsp_dist_multigpu_hip.out: pfsp_dist_multigpu_hip.o $(LIBPATH)/c_taillard.o $(LIBPATH)/c_bound_simple.o $(LIBPATH)/c_bound_johnson.o $(LIBPATH)/PFSP_node.o $(LIBPATH)/Pool_ext.o $(LIBPATH)/Auxiliary.o $(LIBPATH)/evaluate_hip.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $(MPI_INCLUDE_G5K) $(MPI_LIB_G5K) -lmpi_cxx -lmpi -lopen-pal -fopenmp $^ -o $@

--- a/baselines/pfsp/makefile
+++ b/baselines/pfsp/makefile
@@ -20,21 +20,18 @@ CUDA_LIB_G5K     := -L/usr/local/cuda-11.2/targets/x86_64-linux/lib
 LIBPATH := lib
 
 # Source files
-C_SOURCES    := $(LIBPATH)/c_taillard.c $(LIBPATH)/c_bound_simple.c $(LIBPATH)/c_bound_johnson.c $(LIBPATH)/PFSP_node.c $(LIBPATH)/Pool.c $(LIBPATH)/Pool_ext.c $(LIBPATH)/Auxiliary.c pfsp_c.c pfsp_gpu_cuda.c pfsp_multigpu_cuda.c pfsp_dist_multigpu_cuda.c
-CUDA_SOURCES := $(LIBPATH)/evaluate.cu $(LIBPATH)/c_bounds_gpu.cu
-HIP_SOURCES  :=
+C_SOURCES        := pfsp_c.c pfsp_gpu_cuda.c pfsp_multigpu_cuda.c pfsp_dist_multigpu_cuda.c
+C_LIB_SOURCES    := $(LIBPATH)/c_taillard.c $(LIBPATH)/c_bound_simple.c $(LIBPATH)/c_bound_johnson.c $(LIBPATH)/PFSP_node.c $(LIBPATH)/Pool.c $(LIBPATH)/Pool_ext.c $(LIBPATH)/Auxiliary.c
+CUDA_LIB_SOURCES := $(LIBPATH)/evaluate.cu $(LIBPATH)/c_bounds_gpu.cu
 
 # Object files
-C_OBJECTS    := $(C_SOURCES:.c=.o)
-CUDA_OBJECTS := $(CUDA_SOURCES:.cu=.o)
-HIP_OBJECTS  := $(HIP_SOURCES:hip.cu=hip.o)
+C_OBJECTS        := $(C_SOURCES:.c=.o)
+C_LIB_OBJECTS    := $(C_LIB_SOURCES:.c=.o)
+CUDA_LIB_OBJECTS := $(CUDA_LIB_SOURCES:.cu=.o)
+HIP_OBJECTS      := $(HIP_SOURCES:hip.cu=hip.o)
 
 # Executable names
 EXECUTABLES := pfsp_c.out pfsp_gpu_cuda.out pfsp_multigpu_cuda.out pfsp_dist_multigpu_cuda.out pfsp_gpu_hip.out pfsp_multigpu_hip.out pfsp_dist_multigpu_hip.out
-
-# Library paths
-#C_PFSP_LIBPATH := lib/c_bound_simple.c lib/c_bound_johnson.c lib/c_taillard.c
-#CUDA_PFSP_LIBPATH := lib/c_bounds_gpu.cu
 
 # Build codes
 all: $(EXECUTABLES)
@@ -46,8 +43,12 @@ all: $(EXECUTABLES)
 pfsp_dist_multigpu_cuda.o: pfsp_dist_multigpu_cuda.c
 	$(MPI_COMPILER) $(C_COMMON_OPTS) -c -fopenmp $< -o $@ $(CUDA_INCLUDE_G5K)
 
+# Pattern rule for C library source files
+$(LIBPATH)/%.o: $(LIBPATH)/%.c
+	$(C_COMPILER) $(C_COMMON_OPTS) -c $< -o $@
+
 # Pattern rule for CUDA source files
-%.o: %.cu
+$(LIBPATH)/%.o: $(LIBPATH)/%.cu
 	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) -c $< -o $@
 
 # Build executable for CPU only


### PR DESCRIPTION
This PR drastically improves the compilation for the PFSP baseline files. It solves the issues mentioned in #12 and adds a command-line option `SYSTEM={g5k,lumi}` (defaults to `g5k`) that transparently manages the platform-specific flags and libraries.

Usage: `make SYSTEM=lumi pfsp_multigpu_hip.o`

Resolves #12 