### PR TITLE
Improve baseline codes for N-Queens

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Unstable command-line options:
 
 - CUDA multi-GPU launch to solve the 17-Queens instance using 4 GPU devices:
 ```
-./nqueens_multigpu_cuda.o -N 17 -D 4
+./nqueens_multigpu_cuda.out -N 17 -D 4
 ```
 
 ## Related publications

--- a/baselines/nqueens/lib/NQueens_node.c
+++ b/baselines/nqueens/lib/NQueens_node.c
@@ -1,0 +1,13 @@
+/*******************************************************************************
+Implementation of N-Queens Nodes.
+*******************************************************************************/
+
+#include "NQueens_node.h"
+
+void initRoot(Node* root, const int N)
+{
+  root->depth = 0;
+  for (uint8_t i = 0; i < N; i++) {
+    root->board[i] = i;
+  }
+}

--- a/baselines/nqueens/lib/NQueens_node.h
+++ b/baselines/nqueens/lib/NQueens_node.h
@@ -1,0 +1,27 @@
+#ifndef NQUEENS_NODE_H
+#define NQUEENS_NODE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#define BLOCK_SIZE 512
+
+#define MAX_QUEENS 20
+
+typedef struct
+{
+  uint8_t depth;
+  uint8_t board[MAX_QUEENS];
+} Node;
+
+void initRoot(Node* root, const int N);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NQUEENS_NODE_H

--- a/baselines/nqueens/lib/NQueens_node.h
+++ b/baselines/nqueens/lib/NQueens_node.h
@@ -8,8 +8,6 @@ extern "C" {
 #include <stdlib.h>
 #include <stdint.h>
 
-#define BLOCK_SIZE 512
-
 #define MAX_QUEENS 20
 
 typedef struct

--- a/baselines/nqueens/lib/Pool.c
+++ b/baselines/nqueens/lib/Pool.c
@@ -1,0 +1,48 @@
+#include "Pool.h"
+#include <stdlib.h>
+
+void initSinglePool(SinglePool* pool)
+{
+  pool->elements = (Node*)malloc(CAPACITY * sizeof(Node));
+  pool->capacity = CAPACITY;
+  pool->front = 0;
+  pool->size = 0;
+}
+
+void pushBack(SinglePool* pool, Node node)
+{
+  if (pool->front + pool->size >= pool->capacity) {
+    pool->capacity *= 2;
+    pool->elements = (Node*)realloc(pool->elements, pool->capacity * sizeof(Node));
+  }
+
+  pool->elements[pool->front + pool->size] = node;
+  pool->size += 1;
+}
+
+Node popBack(SinglePool* pool, int* hasWork)
+{
+  if (pool->size > 0) {
+    *hasWork = 1;
+    pool->size -= 1;
+    return pool->elements[pool->front + pool->size];
+  }
+
+  return (Node){0};
+}
+
+Node popFront(SinglePool* pool, int* hasWork)
+{
+  if (pool->size > 0) {
+    *hasWork = 1;
+    pool->size--;
+    return pool->elements[pool->front++];
+  }
+
+  return (Node){0};
+}
+
+void deleteSinglePool(SinglePool* pool)
+{
+  free(pool->elements);
+}

--- a/baselines/nqueens/lib/Pool.h
+++ b/baselines/nqueens/lib/Pool.h
@@ -1,0 +1,41 @@
+#ifndef POOL_H
+#define POOL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "PFSP_node.h"
+
+/*******************************************************************************
+Implementation of a dynamic-sized single pool data structure.
+Its initial capacity is 1024, and we reallocate a new container with double
+the capacity when it is full. Since we perform only DFS, it only supports
+'pushBack' and 'popBack' operations.
+*******************************************************************************/
+
+#define CAPACITY 1024
+
+typedef struct
+{
+  Node* elements;
+  int capacity;
+  int front;
+  int size;
+} SinglePool;
+
+void initSinglePool(SinglePool* pool);
+
+void pushBack(SinglePool* pool, Node node);
+
+Node popBack(SinglePool* pool, int* hasWork);
+
+Node popFront(SinglePool* pool, int* hasWork);
+
+void deleteSinglePool(SinglePool* pool);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // POOL_H

--- a/baselines/nqueens/lib/Pool.h
+++ b/baselines/nqueens/lib/Pool.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include "PFSP_node.h"
+#include "NQueens_node.h"
 
 /*******************************************************************************
 Implementation of a dynamic-sized single pool data structure.

--- a/baselines/nqueens/makefile
+++ b/baselines/nqueens/makefile
@@ -11,6 +11,8 @@ HIP_COMMON_OPTS  := $(C_COMMON_OPTS) -offload-arch=gfx906
 
 HIP_PATCH_G5K    := DEVICE_LIB_PATH=/opt/rocm-4.5.0/amdgcn/bitcode/
 
+LIBPATH := lib
+
 # Source files
 C_SOURCES    := nqueens_c.c
 CUDA_SOURCES := nqueens_gpu_cuda.cu nqueens_multigpu_cuda.cu
@@ -23,30 +25,40 @@ HIP_OBJECTS  := $(CUDA_SOURCES:cuda.cu=hip.o)
 # Build codes
 all: $(C_OBJECTS) $(CUDA_OBJECTS) $(HIP_OBJECTS)
 
-# Pattern rule for C source files
-nqueens_c.o: nqueens_c.c
-	$(C_COMPILER) $(C_COMMON_OPTS) $< -o $@
+# Pattern rule for C library source files
+$(LIBPATH)/%.o: $(LIBPATH)/%.c
+	$(C_COMPILER) $(C_COMMON_OPTS) -c $< -o $@
 
-# Pattern rule for CUDA source files
+# Build executable for sequential in C
+nqueens_c.o: nqueens_c.c $(LIBPATH)/NQueens_node.o
+	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@
+
+# Build executable for single-GPU in C+CUDA
 nqueens_gpu_cuda.o: nqueens_gpu_cuda.cu
 	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) $< -o $@
 
-# Pattern rule for hybrid OpenMP+CUDA source files
+# Build executable for multi-GPU in C+OpenMP+CUDA
 nqueens_multigpu_cuda.o: nqueens_multigpu_cuda.cu
 	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) -Xcompiler -fopenmp $< -o $@
 
-# Pattern rule for HIP source files
+# Build executable for single-GPU in C+HIP
 nqueens_gpu_hip.o: nqueens_gpu_cuda.cu
 	hipify-perl $< > $<.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $<.hip -o $@
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
 
-# Pattern rule for hybrid OpenMP+HIP source files
+nqueens_gpu_hip.out: nqueens_gpu_hip.o $(LIBPATH)/NQueens_node.o
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $^ -o $@
+
+# Build executable for multi-GPU in C+OpenMP+HIP
 nqueens_multigpu_hip.o: nqueens_multigpu_cuda.cu
 	hipify-perl $< > $<.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp $<.hip -o $@
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp -c $<.hip -o $@
+
+nqueens_multigpu_hip.out: nqueens_multigpu_hip.o $(LIBPATH)/NQueens_node.o
+	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp $^ -o $@
 
 # Utilities
 .PHONY: clean
 
 clean:
-	rm -f $(C_OBJECTS) $(CUDA_OBJECTS) $(HIP_OBJECTS) *.hip
+	rm -f *.out *.o *.hip $(LIBPATH)/*.o

--- a/baselines/nqueens/makefile
+++ b/baselines/nqueens/makefile
@@ -1,5 +1,7 @@
 SHELL := /bin/bash
 
+SYSTEM ?= g5k
+
 # Compilers & common options
 C_COMPILER    := gcc
 CUDA_COMPILER := nvcc
@@ -9,21 +11,27 @@ C_COMMON_OPTS    := -O3
 CUDA_COMMON_OPTS := $(C_COMMON_OPTS) -arch=sm_70
 HIP_COMMON_OPTS  := $(C_COMMON_OPTS) -offload-arch=gfx906
 
-HIP_PATCH_G5K    := DEVICE_LIB_PATH=/opt/rocm-4.5.0/amdgcn/bitcode/
-
 LIBPATH := lib
 
+# Platform-specific flags and libraries
+ifeq ($(SYSTEM), g5k)
+  # HIP compiler patch
+  HIP_COMPILER := DEVICE_LIB_PATH=/opt/rocm-4.5.0/amdgcn/bitcode/ hipcc
+else ifeq ($(SYSTEM), lumi)
+
+endif
+
 # Source files
-C_SOURCES    := nqueens_c.c
-CUDA_SOURCES := nqueens_gpu_cuda.cu nqueens_multigpu_cuda.cu
+# C_SOURCES    := nqueens_c.c
+# CUDA_SOURCES := nqueens_gpu_cuda.cu nqueens_multigpu_cuda.cu
 
 # Object files
-C_OBJECTS    := $(C_SOURCES:.c=.o)
-CUDA_OBJECTS := $(CUDA_SOURCES:.cu=.o)
-HIP_OBJECTS  := $(CUDA_SOURCES:cuda.cu=hip.o)
+# C_OBJECTS    := $(C_SOURCES:.c=.o)
+# CUDA_OBJECTS := $(CUDA_SOURCES:.cu=.o)
+# HIP_OBJECTS  := $(CUDA_SOURCES:cuda.cu=hip.o)
 
-# Build codes
-all: $(C_OBJECTS) $(CUDA_OBJECTS) $(HIP_OBJECTS)
+# Executable names
+all: nqueens_c.o nqueens_gpu_cuda.o nqueens_multigpu_cuda.o nqueens_gpu_hip.out nqueens_multigpu_hip.out
 
 # Pattern rule for C library source files
 $(LIBPATH)/%.o: $(LIBPATH)/%.c
@@ -41,21 +49,23 @@ nqueens_gpu_cuda.o: nqueens_gpu_cuda.cu
 nqueens_multigpu_cuda.o: nqueens_multigpu_cuda.cu
 	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) -Xcompiler -fopenmp $< -o $@
 
+# TODO: find an elegant way to avoid intermediate *_hip.o object files
+
 # Build executable for single-GPU in C+HIP
 nqueens_gpu_hip.o: nqueens_gpu_cuda.cu
 	hipify-perl $< > $<.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
+	$(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
 
 nqueens_gpu_hip.out: nqueens_gpu_hip.o $(LIBPATH)/NQueens_node.o $(LIBPATH)/Pool.o
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $^ -o $@
+	$(HIP_COMPILER) $(HIP_COMMON_OPTS) $^ -o $@
 
 # Build executable for multi-GPU in C+OpenMP+HIP
 nqueens_multigpu_hip.o: nqueens_multigpu_cuda.cu
 	hipify-perl $< > $<.hip
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp -c $<.hip -o $@
+	$(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp -c $<.hip -o $@
 
 nqueens_multigpu_hip.out: nqueens_multigpu_hip.o $(LIBPATH)/NQueens_node.o $(LIBPATH)/Pool.o
-	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp $^ -o $@
+	$(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp $^ -o $@
 
 # Utilities
 .PHONY: clean

--- a/baselines/nqueens/makefile
+++ b/baselines/nqueens/makefile
@@ -42,12 +42,12 @@ nqueens_c.out: nqueens_c.c $(LIBPATH)/NQueens_node.o $(LIBPATH)/Pool.o
 	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@
 
 # Build executable for single-GPU in C+CUDA
-nqueens_gpu_cuda.out: nqueens_gpu_cuda.cu
-	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) $< -o $@
+nqueens_gpu_cuda.out: nqueens_gpu_cuda.cu $(LIBPATH)/NQueens_node.o $(LIBPATH)/Pool.o
+	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) $^ -o $@
 
 # Build executable for multi-GPU in C+OpenMP+CUDA
-nqueens_multigpu_cuda.out: nqueens_multigpu_cuda.cu
-	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) -Xcompiler -fopenmp $< -o $@
+nqueens_multigpu_cuda.out: nqueens_multigpu_cuda.cu $(LIBPATH)/NQueens_node.o $(LIBPATH)/Pool.o
+	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) -Xcompiler -fopenmp $^ -o $@
 
 # TODO: find an elegant way to avoid intermediate *_hip.o object files
 

--- a/baselines/nqueens/makefile
+++ b/baselines/nqueens/makefile
@@ -30,7 +30,7 @@ $(LIBPATH)/%.o: $(LIBPATH)/%.c
 	$(C_COMPILER) $(C_COMMON_OPTS) -c $< -o $@
 
 # Build executable for sequential in C
-nqueens_c.o: nqueens_c.c $(LIBPATH)/NQueens_node.o
+nqueens_c.o: nqueens_c.c $(LIBPATH)/NQueens_node.o $(LIBPATH)/Pool.o
 	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@
 
 # Build executable for single-GPU in C+CUDA
@@ -46,7 +46,7 @@ nqueens_gpu_hip.o: nqueens_gpu_cuda.cu
 	hipify-perl $< > $<.hip
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -c $<.hip -o $@
 
-nqueens_gpu_hip.out: nqueens_gpu_hip.o $(LIBPATH)/NQueens_node.o
+nqueens_gpu_hip.out: nqueens_gpu_hip.o $(LIBPATH)/NQueens_node.o $(LIBPATH)/Pool.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) $^ -o $@
 
 # Build executable for multi-GPU in C+OpenMP+HIP
@@ -54,7 +54,7 @@ nqueens_multigpu_hip.o: nqueens_multigpu_cuda.cu
 	hipify-perl $< > $<.hip
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp -c $<.hip -o $@
 
-nqueens_multigpu_hip.out: nqueens_multigpu_hip.o $(LIBPATH)/NQueens_node.o
+nqueens_multigpu_hip.out: nqueens_multigpu_hip.o $(LIBPATH)/NQueens_node.o $(LIBPATH)/Pool.o
 	$(HIP_PATCH_G5K) $(HIP_COMPILER) $(HIP_COMMON_OPTS) -fopenmp $^ -o $@
 
 # Utilities

--- a/baselines/nqueens/makefile
+++ b/baselines/nqueens/makefile
@@ -31,22 +31,22 @@ endif
 # HIP_OBJECTS  := $(CUDA_SOURCES:cuda.cu=hip.o)
 
 # Executable names
-all: nqueens_c.o nqueens_gpu_cuda.o nqueens_multigpu_cuda.o nqueens_gpu_hip.out nqueens_multigpu_hip.out
+all: nqueens_c.out nqueens_gpu_cuda.out nqueens_multigpu_cuda.out nqueens_gpu_hip.out nqueens_multigpu_hip.out
 
 # Pattern rule for C library source files
 $(LIBPATH)/%.o: $(LIBPATH)/%.c
 	$(C_COMPILER) $(C_COMMON_OPTS) -c $< -o $@
 
 # Build executable for sequential in C
-nqueens_c.o: nqueens_c.c $(LIBPATH)/NQueens_node.o $(LIBPATH)/Pool.o
+nqueens_c.out: nqueens_c.c $(LIBPATH)/NQueens_node.o $(LIBPATH)/Pool.o
 	$(C_COMPILER) $(C_COMMON_OPTS) $^ -o $@
 
 # Build executable for single-GPU in C+CUDA
-nqueens_gpu_cuda.o: nqueens_gpu_cuda.cu
+nqueens_gpu_cuda.out: nqueens_gpu_cuda.cu
 	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) $< -o $@
 
 # Build executable for multi-GPU in C+OpenMP+CUDA
-nqueens_multigpu_cuda.o: nqueens_multigpu_cuda.cu
+nqueens_multigpu_cuda.out: nqueens_multigpu_cuda.cu
 	$(CUDA_COMPILER) $(CUDA_COMMON_OPTS) -Xcompiler -fopenmp $< -o $@
 
 # TODO: find an elegant way to avoid intermediate *_hip.o object files

--- a/baselines/nqueens/nqueens_c.c
+++ b/baselines/nqueens/nqueens_c.c
@@ -9,25 +9,7 @@
 #include <unistd.h>
 #include <time.h>
 
-/*******************************************************************************
-Implementation of N-Queens Nodes.
-*******************************************************************************/
-
-#define MAX_QUEENS 20
-
-typedef struct
-{
-  uint8_t depth;
-  uint8_t board[MAX_QUEENS];
-} Node;
-
-void initRoot(Node* root, const int N)
-{
-  root->depth = 0;
-  for (uint8_t i = 0; i < N; i++) {
-    root->board[i] = i;
-  }
-}
+#include "lib/NQueens_node.h"
 
 /*******************************************************************************
 Implementation of a dynamic-sized single pool data structure.

--- a/baselines/nqueens/nqueens_c.c
+++ b/baselines/nqueens/nqueens_c.c
@@ -10,54 +10,7 @@
 #include <time.h>
 
 #include "lib/NQueens_node.h"
-
-/*******************************************************************************
-Implementation of a dynamic-sized single pool data structure.
-Its initial capacity is 1024, and we reallocate a new container with double
-the capacity when it is full. Since we perform only DFS, it only supports
-'pushBack' and 'popBack' operations.
-*******************************************************************************/
-
-#define CAPACITY 1024
-
-typedef struct
-{
-  Node* elements;
-  int capacity;
-  int size;
-} SinglePool;
-
-void initSinglePool(SinglePool* pool)
-{
-  pool->elements = (Node*)malloc(CAPACITY * sizeof(Node));
-  pool->capacity = CAPACITY;
-  pool->size = 0;
-}
-
-void pushBack(SinglePool* pool, Node node)
-{
-  if (pool->size >= pool->capacity) {
-    pool->capacity *= 2;
-    pool->elements = (Node*)realloc(pool->elements, pool->capacity * sizeof(Node));
-  }
-
-  pool->elements[pool->size++] = node;
-}
-
-Node popBack(SinglePool* pool, int* hasWork)
-{
-  if (pool->size > 0) {
-    *hasWork = 1;
-    return pool->elements[--pool->size];
-  }
-
-  return (Node){0};
-}
-
-void deleteSinglePool(SinglePool* pool)
-{
-  free(pool->elements);
-}
+#include "lib/Pool.h"
 
 /*******************************************************************************
 Implementation of the sequential N-Queens search.

--- a/baselines/nqueens/nqueens_c.c
+++ b/baselines/nqueens/nqueens_c.c
@@ -26,18 +26,23 @@ void parse_parameters(int argc, char* argv[], int* N, int* G)
   while ((opt = getopt(argc, argv, "N:g:")) != -1) {
     value = atoi(optarg);
 
-    if (value <= 0) {
-      printf("All parameters must be positive integers.\n");
-      exit(EXIT_FAILURE);
-    }
-
     switch (opt) {
       case 'N':
+        if (value < 1) {
+          fprintf(stderr, "Error: N must be a positive integer.\n");
+          exit(EXIT_FAILURE);
+        }
         *N = value;
         break;
+
       case 'g':
+        if (value < 1) {
+          fprintf(stderr, "Error: g must be a positive integer.\n");
+          exit(EXIT_FAILURE);
+        }
         *G = value;
         break;
+
       default:
         fprintf(stderr, "Usage: %s -N value -g value\n", argv[0]);
         exit(EXIT_FAILURE);
@@ -133,6 +138,7 @@ void nqueens_search(const int N, const int G,  unsigned long long int* exploredT
 
     decompose(N, G, parent, exploredTree, exploredSol, &pool);
   }
+
   clock_gettime(CLOCK_MONOTONIC_RAW, &end);
   *elapsedTime = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
 

--- a/baselines/nqueens/nqueens_c.c
+++ b/baselines/nqueens/nqueens_c.c
@@ -81,16 +81,14 @@ void deleteSinglePool(SinglePool* pool)
 Implementation of the sequential N-Queens search.
 *******************************************************************************/
 
-void parse_parameters(int argc, char* argv[], int* N, int* G, int* m, int* M)
+void parse_parameters(int argc, char* argv[], int* N, int* G)
 {
   *N = 14;
   *G = 1;
-  *m = 25;
-  *M = 50000;
 
   int opt, value;
 
-  while ((opt = getopt(argc, argv, "N:g:m:M:")) != -1) {
+  while ((opt = getopt(argc, argv, "N:g:")) != -1) {
     value = atoi(optarg);
 
     if (value <= 0) {
@@ -105,14 +103,8 @@ void parse_parameters(int argc, char* argv[], int* N, int* G, int* m, int* M)
       case 'g':
         *G = value;
         break;
-      case 'm':
-        *m = value;
-        break;
-      case 'M':
-        *M = value;
-        break;
       default:
-        fprintf(stderr, "Usage: %s -N value -g value -m value -M value\n", argv[0]);
+        fprintf(stderr, "Usage: %s -N value -g value\n", argv[0]);
         exit(EXIT_FAILURE);
     }
   }
@@ -185,9 +177,8 @@ void decompose(const int N, const int G, const Node parent,
 }
 
 // Sequential N-Queens search.
-void nqueens_search(const int N, const int G, const int m, const int M,
-  unsigned long long int* exploredTree, unsigned long long int* exploredSol,
-  double* elapsedTime)
+void nqueens_search(const int N, const int G,  unsigned long long int* exploredTree,
+  unsigned long long int* exploredSol, double* elapsedTime)
 {
   Node root;
   initRoot(&root, N);
@@ -217,8 +208,8 @@ void nqueens_search(const int N, const int G, const int m, const int M,
 
 int main(int argc, char* argv[])
 {
-  int N, G, m, M;
-  parse_parameters(argc, argv, &N, &G, &m, &M);
+  int N, G;
+  parse_parameters(argc, argv, &N, &G);
   print_settings(N, G);
 
   unsigned long long int exploredTree = 0;
@@ -226,7 +217,7 @@ int main(int argc, char* argv[])
 
   double elapsedTime;
 
-  nqueens_search(N, G, m, M, &exploredTree, &exploredSol, &elapsedTime);
+  nqueens_search(N, G, &exploredTree, &exploredSol, &elapsedTime);
 
   print_results(exploredTree, exploredSol, elapsedTime);
 

--- a/baselines/nqueens/nqueens_gpu_cuda.cu
+++ b/baselines/nqueens/nqueens_gpu_cuda.cu
@@ -10,29 +10,11 @@
 #include <time.h>
 #include "cuda_runtime.h"
 
+#include "lib/NQueens_node.h"
+
 #define BLOCK_SIZE 512
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-
-/*******************************************************************************
-Implementation of N-Queens Nodes.
-*******************************************************************************/
-
-#define MAX_QUEENS 20
-
-typedef struct
-{
-  uint8_t depth;
-  uint8_t board[MAX_QUEENS];
-} Node;
-
-void initRoot(Node* root, const int N)
-{
-  root->depth = 0;
-  for (uint8_t i = 0; i < N; i++) {
-    root->board[i] = i;
-  }
-}
 
 /*******************************************************************************
 Implementation of a dynamic-sized single pool data structure.

--- a/baselines/nqueens/nqueens_gpu_cuda.cu
+++ b/baselines/nqueens/nqueens_gpu_cuda.cu
@@ -33,24 +33,39 @@ void parse_parameters(int argc, char* argv[], int* N, int* G, int* m, int* M)
   while ((opt = getopt(argc, argv, "N:g:m:M:")) != -1) {
     value = atoi(optarg);
 
-    if (value <= 0) {
-      printf("All parameters must be positive integers.\n");
-      exit(EXIT_FAILURE);
-    }
-
     switch (opt) {
       case 'N':
+        if (value < 1) {
+          fprintf(stderr, "Error: N must be a positive integer.\n");
+          exit(EXIT_FAILURE);
+        }
         *N = value;
         break;
+
       case 'g':
+        if (value < 1) {
+          fprintf(stderr, "Error: g must be a positive integer.\n");
+          exit(EXIT_FAILURE);
+        }
         *G = value;
         break;
+
       case 'm':
+        if (value < 1) {
+          fprintf(stderr, "Error: m must be a positive integer.\n");
+          exit(EXIT_FAILURE);
+        }
         *m = value;
         break;
+
       case 'M':
+        if (value < *m) {
+          fprintf(stderr, "Error: M must be a positive integer, greater or equal to m.\n");
+          exit(EXIT_FAILURE);
+        }
         *M = value;
         break;
+
       default:
         fprintf(stderr, "Usage: %s -N value -g value -m value -M value\n", argv[0]);
         exit(EXIT_FAILURE);

--- a/baselines/nqueens/nqueens_gpu_cuda.cu
+++ b/baselines/nqueens/nqueens_gpu_cuda.cu
@@ -18,7 +18,7 @@
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 /*******************************************************************************
-Implementation of the single-core single-GPU N-Queens search.
+Implementation of the single-GPU N-Queens search.
 *******************************************************************************/
 
 void parse_parameters(int argc, char* argv[], int* N, int* G, int* m, int* M)
@@ -207,7 +207,6 @@ void nqueens_search(const int N, const int G, const int m, const int M,
 
   pushBack(&pool, root);
 
-  // int count = 0;
   clock_t startTime = clock();
 
   Node* parents = (Node*)malloc(M * sizeof(Node));
@@ -242,7 +241,6 @@ void nqueens_search(const int N, const int G, const int m, const int M,
 
       const int nbBlocks = ceil((double)numLabels / BLOCK_SIZE);
 
-      // count += 1;
       evaluate_gpu<<<nbBlocks, BLOCK_SIZE>>>(N, G, parents_d, labels_d, numLabels);
 
       cudaMemcpy(labels, labels_d, numLabels * sizeof(uint8_t), cudaMemcpyDeviceToHost);
@@ -261,7 +259,6 @@ void nqueens_search(const int N, const int G, const int m, const int M,
   *elapsedTime = (double)(endTime - startTime) / CLOCKS_PER_SEC;
 
   printf("\nExploration terminated.\n");
-  // printf("Cuda kernel calls: %d\n", count);
 
   deleteSinglePool(&pool);
 }

--- a/baselines/nqueens/nqueens_gpu_cuda.cu
+++ b/baselines/nqueens/nqueens_gpu_cuda.cu
@@ -11,58 +11,11 @@
 #include "cuda_runtime.h"
 
 #include "lib/NQueens_node.h"
+#include "lib/Pool.h"
 
 #define BLOCK_SIZE 512
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-
-/*******************************************************************************
-Implementation of a dynamic-sized single pool data structure.
-Its initial capacity is 1024, and we reallocate a new container with double
-the capacity when it is full. Since we perform only DFS, it only supports
-'pushBack' and 'popBack' operations.
-*******************************************************************************/
-
-#define CAPACITY 1024
-
-typedef struct
-{
-  Node* elements;
-  int capacity;
-  int size;
-} SinglePool;
-
-void initSinglePool(SinglePool* pool)
-{
-  pool->elements = (Node*)malloc(CAPACITY * sizeof(Node));
-  pool->capacity = CAPACITY;
-  pool->size = 0;
-}
-
-void pushBack(SinglePool* pool, Node node)
-{
-  if (pool->size >= pool->capacity) {
-    pool->capacity *= 2;
-    pool->elements = (Node*)realloc(pool->elements, pool->capacity * sizeof(Node));
-  }
-
-  pool->elements[pool->size++] = node;
-}
-
-Node popBack(SinglePool* pool, int* hasWork)
-{
-  if (pool->size > 0) {
-    *hasWork = 1;
-    return pool->elements[--pool->size];
-  }
-
-  return (Node){0};
-}
-
-void deleteSinglePool(SinglePool* pool)
-{
-  free(pool->elements);
-}
 
 /*******************************************************************************
 Implementation of the single-core single-GPU N-Queens search.

--- a/baselines/nqueens/nqueens_multigpu_cuda.cu
+++ b/baselines/nqueens/nqueens_multigpu_cuda.cu
@@ -222,7 +222,6 @@ void nqueens_search(const int N, const int G, const int m, const int M, const in
 
   pushBack(&pool, root);
 
-  // int count = 0;
   double startTime, endTime;
 
   /*
@@ -302,7 +301,6 @@ void nqueens_search(const int N, const int G, const int m, const int M, const in
         cudaMemcpy(parents_d, parents, poolSize * sizeof(Node), cudaMemcpyHostToDevice);
 
         const int nbBlocks = ceil((double)numLabels / BLOCK_SIZE);
-        // count += 1;
 
         // call the compute kernel on device (deviceID)
         evaluate_gpu<<<nbBlocks, BLOCK_SIZE>>>(N, G, parents_d, labels_d, numLabels);
@@ -369,7 +367,6 @@ void nqueens_search(const int N, const int G, const int m, const int M, const in
   printf("Elapsed time: %f [s]\n", t3);
 
   printf("\nExploration terminated.\n");
-  // printf("Cuda kernel calls: %d\n", count);
 
   deleteSinglePool(&pool);
 }

--- a/baselines/nqueens/nqueens_multigpu_cuda.cu
+++ b/baselines/nqueens/nqueens_multigpu_cuda.cu
@@ -11,29 +11,11 @@
 #include <omp.h>
 #include "cuda_runtime.h"
 
+#include "lib/NQueens_node.h"
+
 #define BLOCK_SIZE 512
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-
-/*******************************************************************************
-Implementation of N-Queens Nodes.
-*******************************************************************************/
-
-#define MAX_QUEENS 20
-
-typedef struct
-{
-  uint8_t depth;
-  uint8_t board[MAX_QUEENS];
-} Node;
-
-void initRoot(Node* root, const int N)
-{
-  root->depth = 0;
-  for (uint8_t i = 0; i < N; i++) {
-    root->board[i] = i;
-  }
-}
 
 /*******************************************************************************
 Implementation of a dynamic-sized single pool data structure.

--- a/baselines/nqueens/nqueens_multigpu_cuda.cu
+++ b/baselines/nqueens/nqueens_multigpu_cuda.cu
@@ -12,73 +12,11 @@
 #include "cuda_runtime.h"
 
 #include "lib/NQueens_node.h"
+#include "lib/Pool.h"
 
 #define BLOCK_SIZE 512
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-
-/*******************************************************************************
-Implementation of a dynamic-sized single pool data structure.
-Its initial capacity is 1024, and we reallocate a new container with double
-the capacity when it is full. Since we perform only DFS, it only supports
-'pushBack' and 'popBack' operations.
-*******************************************************************************/
-
-#define CAPACITY 1024
-
-typedef struct
-{
-  Node* elements;
-  int capacity;
-  int front;
-  int size;
-} SinglePool;
-
-void initSinglePool(SinglePool* pool)
-{
-  pool->elements = (Node*)malloc(CAPACITY * sizeof(Node));
-  pool->capacity = CAPACITY;
-  pool->front = 0;
-  pool->size = 0;
-}
-
-void pushBack(SinglePool* pool, Node node)
-{
-  if (pool->front + pool->size >= pool->capacity) {
-    pool->capacity *= 2;
-    pool->elements = (Node*)realloc(pool->elements, pool->capacity * sizeof(Node));
-  }
-
-  pool->elements[pool->front + pool->size] = node;
-  pool->size += 1;
-}
-
-Node popBack(SinglePool* pool, int* hasWork)
-{
-  if (pool->size > 0) {
-    *hasWork = 1;
-    pool->size -= 1;
-    return pool->elements[pool->front + pool->size];
-  }
-
-  return (Node){0};
-}
-
-Node popFront(SinglePool* pool, int* hasWork)
-{
-  if (pool->size > 0) {
-    *hasWork = 1;
-    pool->size--;
-    return pool->elements[pool->front++];
-  }
-
-  return (Node){0};
-}
-
-void deleteSinglePool(SinglePool* pool)
-{
-  free(pool->elements);
-}
 
 /*******************************************************************************
 Implementation of the multi-GPU N-Queens search.

--- a/baselines/nqueens/nqueens_multigpu_cuda.cu
+++ b/baselines/nqueens/nqueens_multigpu_cuda.cu
@@ -42,20 +42,45 @@ void parse_parameters(int argc, char* argv[], int* N, int* G, int* m, int* M, in
 
     switch (opt) {
       case 'N':
+        if (value < 1) {
+          fprintf(stderr, "Error: N must be a positive integer.\n");
+          exit(EXIT_FAILURE);
+        }
         *N = value;
         break;
+
       case 'g':
+        if (value < 1) {
+          fprintf(stderr, "Error: g must be a positive integer.\n");
+          exit(EXIT_FAILURE);
+        }
         *G = value;
         break;
+
       case 'm':
+        if (value < 1) {
+          fprintf(stderr, "Error: m must be a positive integer.\n");
+          exit(EXIT_FAILURE);
+        }
         *m = value;
         break;
+
       case 'M':
+        if (value < *m) {
+          fprintf(stderr, "Error: M must be a positive integer, greater or equal to m.\n");
+          exit(EXIT_FAILURE);
+        }
         *M = value;
         break;
+
       case 'D':
+        if (value < 1) {
+          fprintf(stderr, "Error: D must be a positive integer.\n");
+          exit(EXIT_FAILURE);
+        }
         *D = value;
         break;
+
       default:
         fprintf(stderr, "Usage: %s -N value -g value -m value -M value -D value\n", argv[0]);
         exit(EXIT_FAILURE);


### PR DESCRIPTION
This PR improves baseline codes for N-Queens, inspired by what have been done for PFSP. This includes:
- Refactor of `makefile` to support portable options (similar to #13);
- Avoid the redundant implementations of `Pool` and `Node`;
- Improve error messages in arguments parser;
- Clean up.

The main benefits of this PR is to reduce maintenance effort and to favour portable compilation.