### PR TITLE
Implement intra-node work stealing for NQueens problem

### DIFF
--- a/baselines/nqueens/lib/Pool.c
+++ b/baselines/nqueens/lib/Pool.c
@@ -1,6 +1,8 @@
 #include "Pool.h"
 #include <stdlib.h>
 
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
 void initSinglePool(SinglePool* pool)
 {
   pool->elements = (Node*)malloc(CAPACITY * sizeof(Node));
@@ -29,6 +31,19 @@ Node popBack(SinglePool* pool, int* hasWork)
   }
 
   return (Node){0};
+}
+
+int popBackBulk(SinglePool* pool, const int m, const int M, Node* parents) {
+  if (pool->size >= m) {
+    const int poolSize = MIN(pool->size, M);
+    pool->size -= poolSize;
+    for (int i = 0; i < poolSize; i++) {
+      parents[i] = pool->elements[pool->front + pool->size + i];
+    }
+    return poolSize;
+  }
+
+  return 0;
 }
 
 Node popFront(SinglePool* pool, int* hasWork)

--- a/baselines/nqueens/lib/Pool.h
+++ b/baselines/nqueens/lib/Pool.h
@@ -30,6 +30,8 @@ void pushBack(SinglePool* pool, Node node);
 
 Node popBack(SinglePool* pool, int* hasWork);
 
+int popBackBulk(SinglePool* pool, const int m, const int M, Node* parents);
+
 Node popFront(SinglePool* pool, int* hasWork);
 
 void deleteSinglePool(SinglePool* pool);

--- a/baselines/nqueens/nqueens_gpu_cuda.cu
+++ b/baselines/nqueens/nqueens_gpu_cuda.cu
@@ -298,9 +298,9 @@ void nqueens_search(const int N, const int G, const int m, const int M,
   }
 
   clock_gettime(CLOCK_MONOTONIC_RAW, &end);
-
   double t3 = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
   *elapsedTime = t1 + t2 + t3;
+
   printf("\nSearch on CPU completed\n");
   printf("Size of the explored tree: %llu\n", *exploredTree);
   printf("Number of explored solutions: %llu\n", *exploredSol);

--- a/baselines/nqueens/nqueens_gpu_cuda.cu
+++ b/baselines/nqueens/nqueens_gpu_cuda.cu
@@ -15,8 +15,6 @@
 
 #define BLOCK_SIZE 512
 
-// #define MIN(a, b) ((a) < (b) ? (a) : (b))
-
 /*******************************************************************************
 Implementation of the single-GPU N-Queens search.
 *******************************************************************************/
@@ -158,11 +156,10 @@ __global__ void evaluate_gpu(const int N, const int G, const Node* parents_d, ui
     // If child 'k' is not scheduled, we evaluate its safety 'G' times, otherwise 0.
     if (k >= depth) {
       isSafe = 1;
-      // const int G_notScheduled = G * (k >= depth);
       for (int i = 0; i < depth; i++) {
         const uint8_t pbi = parent.board[i];
 
-        for (int g = 0; g < G/*G_notScheduled*/; g++) {
+        for (int g = 0; g < G; g++) {
           isSafe *= (pbi != queen_num - (depth - i) &&
                      pbi != queen_num + (depth - i));
         }
@@ -254,14 +251,6 @@ void nqueens_search(const int N, const int G, const int m, const int M,
     int poolSize = popBackBulk(&pool, m, M, parents);
 
     if (poolSize > 0) {
-      // poolSize = MIN(poolSize, M);
-      //
-      // for (int i = 0; i < poolSize; i++) {
-      //   int hasWork = 0;
-      //   parents[i] = popBack(&pool, &hasWork);
-      //   if (!hasWork) break;
-      // }
-
       const int numLabels = N * poolSize;
       const int nbBlocks = ceil((double)numLabels / BLOCK_SIZE);
 

--- a/baselines/nqueens/nqueens_gpu_cuda.cu
+++ b/baselines/nqueens/nqueens_gpu_cuda.cu
@@ -15,7 +15,7 @@
 
 #define BLOCK_SIZE 512
 
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
+// #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 /*******************************************************************************
 Implementation of the single-GPU N-Queens search.
@@ -225,7 +225,7 @@ void nqueens_search(const int N, const int G, const int m, const int M,
     Node parent = popFront(&pool, &hasWork);
     if (!hasWork) break;
 
-    decompose(N, G, parent, tree_loc, num_sol, &pool);
+    decompose(N, G, parent, exploredTree, exploredSol, &pool);
   }
 
   clock_gettime(CLOCK_MONOTONIC_RAW, &end);
@@ -251,16 +251,16 @@ void nqueens_search(const int N, const int G, const int m, const int M,
   cudaMalloc(&labels_d, M*N * sizeof(uint8_t));
 
   while (1) {
-    int poolSize = pool.size;
+    int poolSize = popBackBulk(&pool, m, M, parents);
 
-    if (poolSize >= m) {
-      poolSize = MIN(poolSize, M);
-
-      for (int i = 0; i < poolSize; i++) {
-        int hasWork = 0;
-        parents[i] = popBack(&pool, &hasWork);
-        if (!hasWork) break;
-      }
+    if (poolSize > 0) {
+      // poolSize = MIN(poolSize, M);
+      //
+      // for (int i = 0; i < poolSize; i++) {
+      //   int hasWork = 0;
+      //   parents[i] = popBack(&pool, &hasWork);
+      //   if (!hasWork) break;
+      // }
 
       const int numLabels = N * poolSize;
       const int nbBlocks = ceil((double)numLabels / BLOCK_SIZE);
@@ -294,7 +294,7 @@ void nqueens_search(const int N, const int G, const int m, const int M,
     Node parent = popBack(&pool, &hasWork);
     if (!hasWork) break;
 
-    decompose(N, G, parent, tree_loc, num_sol, &pool);
+    decompose(N, G, parent, exploredTree, exploredSol, &pool);
   }
 
   clock_gettime(CLOCK_MONOTONIC_RAW, &end);

--- a/baselines/nqueens/nqueens_gpu_cuda.cu
+++ b/baselines/nqueens/nqueens_gpu_cuda.cu
@@ -127,14 +127,16 @@ void decompose(const int N, const int G, const Node parent,
   if (depth == N) {
     *num_sol += 1;
   }
-  for (int j = depth; j < N; j++) {
-    if (isSafe(G, parent.board, depth, parent.board[j])) {
-      Node child;
-      memcpy(child.board, parent.board, N * sizeof(uint8_t));
-      swap(&child.board[depth], &child.board[j]);
-      child.depth = depth + 1;
-      pushBack(pool, child);
-      *tree_loc += 1;
+  else {
+    for (int j = depth; j < N; j++) {
+      if (isSafe(G, parent.board, depth, parent.board[j])) {
+        Node child;
+        child.depth = depth + 1;
+        memcpy(child.board, parent.board, N * sizeof(uint8_t));
+        swap(&child.board[depth], &child.board[j]);
+        pushBack(pool, child);
+        *tree_loc += 1;
+      }
     }
   }
 }
@@ -151,18 +153,18 @@ __global__ void evaluate_gpu(const int N, const int G, const Node* parents_d, ui
     const uint8_t depth = parent.depth;
     const uint8_t queen_num = parent.board[k];
 
-    uint8_t isSafe = 1;
+    uint8_t isSafe;
 
     // If child 'k' is not scheduled, we evaluate its safety 'G' times, otherwise 0.
     if (k >= depth) {
+      isSafe = 1;
       // const int G_notScheduled = G * (k >= depth);
       for (int i = 0; i < depth; i++) {
         const uint8_t pbi = parent.board[i];
-        int y;
+
         for (int g = 0; g < G/*G_notScheduled*/; g++) {
           isSafe *= (pbi != queen_num - (depth - i) &&
                      pbi != queen_num + (depth - i));
-          y += g;
         }
       }
       labels_d[threadId] = isSafe;
@@ -181,14 +183,16 @@ void generate_children(const int N, const Node* parents, const int size, const u
     if (depth == N) {
       *exploredSol += 1;
     }
-    for (int j = depth; j < N; j++) {
-      if (labels[j + i * N] == 1) {
-        Node child;
-        memcpy(child.board, parent.board, N * sizeof(uint8_t));
-        swap(&child.board[depth], &child.board[j]);
-        child.depth = depth + 1;
-        pushBack(pool, child);
-        *exploredTree += 1;
+    else {
+      for (int j = depth; j < N; j++) {
+        if (labels[j + i * N] == 1) {
+          Node child;
+          child.depth = depth + 1;
+          memcpy(child.board, parent.board, N * sizeof(uint8_t));
+          swap(&child.board[depth], &child.board[j]);
+          pushBack(pool, child);
+          *exploredTree += 1;
+        }
       }
     }
   }
@@ -207,7 +211,36 @@ void nqueens_search(const int N, const int G, const int m, const int M,
 
   pushBack(&pool, root);
 
-  clock_t startTime = clock();
+  // Timers
+  struct timespec start, end;
+
+  /*
+    Step 1: We perform a partial breadth-first search on CPU in order to create
+    a sufficiently large amount of work for GPU computation.
+  */
+  clock_gettime(CLOCK_MONOTONIC_RAW, &start);
+
+  while (pool.size < m) {
+    int hasWork = 0;
+    Node parent = popFront(&pool, &hasWork);
+    if (!hasWork) break;
+
+    decompose(N, G, parent, tree_loc, num_sol, &pool);
+  }
+
+  clock_gettime(CLOCK_MONOTONIC_RAW, &end);
+  double t1 = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+
+  printf("\nInitial search on CPU completed\n");
+  printf("Size of the explored tree: %llu\n", *exploredTree);
+  printf("Number of explored solutions: %llu\n", *exploredSol);
+  printf("Elapsed time: %f [s]\n", t1);
+
+  /*
+    Step 2: We continue the search on GPU in a depth-first manner, until there
+    is not enough work.
+  */
+  clock_gettime(CLOCK_MONOTONIC_RAW, &start);
 
   Node* parents = (Node*)malloc(M * sizeof(Node));
   uint8_t* labels = (uint8_t*)malloc(M*N * sizeof(uint8_t));
@@ -218,16 +251,10 @@ void nqueens_search(const int N, const int G, const int m, const int M,
   cudaMalloc(&labels_d, M*N * sizeof(uint8_t));
 
   while (1) {
-    int hasWork = 0;
-    Node parent = popBack(&pool, &hasWork);
-    if (!hasWork) break;
+    int poolSize = pool.size;
 
-    decompose(N, G, parent, exploredTree, exploredSol, &pool);
-
-    int poolSize = MIN(pool.size, M);
-
-    // If 'poolSize' is sufficiently large, we offload the pool on GPU.
     if (poolSize >= m) {
+      poolSize = MIN(poolSize, M);
 
       for (int i = 0; i < poolSize; i++) {
         int hasWork = 0;
@@ -236,29 +263,56 @@ void nqueens_search(const int N, const int G, const int m, const int M,
       }
 
       const int numLabels = N * poolSize;
-
-      cudaMemcpy(parents_d, parents, poolSize * sizeof(Node), cudaMemcpyHostToDevice);
-
       const int nbBlocks = ceil((double)numLabels / BLOCK_SIZE);
 
+      cudaMemcpy(parents_d, parents, poolSize * sizeof(Node), cudaMemcpyHostToDevice);
       evaluate_gpu<<<nbBlocks, BLOCK_SIZE>>>(N, G, parents_d, labels_d, numLabels);
-
       cudaMemcpy(labels, labels_d, numLabels * sizeof(uint8_t), cudaMemcpyDeviceToHost);
 
       generate_children(N, parents, poolSize, labels, exploredTree, exploredSol, &pool);
     }
+    else {
+      break;
+    }
   }
+
+  clock_gettime(CLOCK_MONOTONIC_RAW, &end);
+  double t2 = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+
+  printf("\nSearch on GPU completed\n");
+  printf("Size of the explored tree: %llu\n", *exploredTree);
+  printf("Number of explored solutions: %llu\n", *exploredSol);
+  printf("Elapsed time: %f [s]\n", t2);
+
+  /*
+    Step 3: We complete the depth-first search on CPU.
+  */
+  clock_gettime(CLOCK_MONOTONIC_RAW, &start);
+
+  while (1) {
+    int hasWork = 0;
+    Node parent = popBack(&pool, &hasWork);
+    if (!hasWork) break;
+
+    decompose(N, G, parent, tree_loc, num_sol, &pool);
+  }
+
+  clock_gettime(CLOCK_MONOTONIC_RAW, &end);
+
+  double t3 = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+  *elapsedTime = t1 + t2 + t3;
+  printf("\nSearch on CPU completed\n");
+  printf("Size of the explored tree: %llu\n", *exploredTree);
+  printf("Number of explored solutions: %llu\n", *exploredSol);
+  printf("Elapsed time: %f [s]\n", t3);
+
+  printf("\nExploration terminated.\n");
 
   cudaFree(parents_d);
   cudaFree(labels_d);
 
   free(parents);
   free(labels);
-
-  clock_t endTime = clock();
-  *elapsedTime = (double)(endTime - startTime) / CLOCKS_PER_SEC;
-
-  printf("\nExploration terminated.\n");
 
   deleteSinglePool(&pool);
 }

--- a/lib/common/Pool.chpl
+++ b/lib/common/Pool.chpl
@@ -46,6 +46,18 @@ module Pool
       return default;
     }
 
+    // Bulk removal from the end of the deque.
+    proc ref popBackBulk(const m: int, const M: int, ref parents) {
+      if (this.size >= m) {
+        const poolSize = min(this.size, M);
+        this.size -= poolSize;
+        parents[0..#poolSize] = this.elements[(this.front + this.size)..#poolSize];
+        return poolSize;
+      }
+
+      return 0;
+    }
+
     // Removal from the front of the deque.
     proc ref popFront(ref hasWork: int) {
       if (this.size > 0) {

--- a/lib/common/Pool_par.chpl
+++ b/lib/common/Pool_par.chpl
@@ -25,6 +25,18 @@ module Pool_par
       this.lock = false;
     }
 
+    proc ref acquireLock() {
+      while true {
+        if this.lock.compareAndSwap(false, true) {
+          return;
+        }
+      }
+    }
+
+    proc ref releaseLock() {
+      this.lock.write(false);
+    }
+
     // Parallel-safe insertion to the end of the deque.
     proc ref pushBack(node: eltType) {
       while true {
@@ -42,6 +54,16 @@ module Pool_par
 
         currentTask.yieldExecution();
       }
+    }
+
+    proc ref pushBackFree(node: eltType) {
+      if (this.front + this.size >= this.capacity) {
+        this.capacity *= 2;
+        this.dom = {0..#this.capacity};
+      }
+
+      this.elements[this.front + this.size] = node;
+      this.size += 1;
     }
 
     // Insertion to the end of the deque. Parallel-safety is not guaranteed.

--- a/lib/common/Pool_par.chpl
+++ b/lib/common/Pool_par.chpl
@@ -30,6 +30,8 @@ module Pool_par
         if this.lock.compareAndSwap(false, true) {
           return;
         }
+
+        currentTask.yieldExecution();
       }
     }
 
@@ -54,16 +56,6 @@ module Pool_par
 
         currentTask.yieldExecution();
       }
-    }
-
-    proc ref pushBackFree(node: eltType) {
-      if (this.front + this.size >= this.capacity) {
-        this.capacity *= 2;
-        this.dom = {0..#this.capacity};
-      }
-
-      this.elements[this.front + this.size] = node;
-      this.size += 1;
     }
 
     // Insertion to the end of the deque. Parallel-safety is not guaranteed.

--- a/nqueens_gpu_chpl.chpl
+++ b/nqueens_gpu_chpl.chpl
@@ -80,14 +80,16 @@ proc decompose(const parent: Node, ref tree_loc: uint, ref num_sol: uint, ref po
   if (depth == N) {
     num_sol += 1;
   }
-  for j in depth..(N-1) {
-    if isSafe(parent.board, depth, parent.board[j]) {
-      var child = new Node();
-      child.depth = depth + 1;
-      child.board = parent.board;
-      child.board[depth] <=> child.board[j];
-      pool.pushBack(child);
-      tree_loc += 1;
+  else {
+    for j in depth..(N-1) {
+      if isSafe(parent.board, depth, parent.board[j]) {
+        var child = new Node();
+        child.depth = depth + 1;
+        child.board = parent.board;
+        child.board[depth] <=> child.board[j];
+        pool.pushBack(child);
+        tree_loc += 1;
+      }
     }
   }
 }
@@ -104,6 +106,7 @@ proc evaluate_gpu(const parents_d: [] Node, const size, ref labels_d)
     const queen_num = parent.board[k];
 
     var isSafe: uint(8);
+
     // If child 'k' is not scheduled, we evaluate its safety 'G' times, otherwise 0.
     if (k >= depth) {
       isSafe = 1;
@@ -132,14 +135,16 @@ proc generate_children(const ref parents: [] Node, const size: int, const ref la
     if (depth == N) {
       exploredSol += 1;
     }
-    for j in depth..(N-1) {
-      if (labels[j + i * N] == 1) {
-        var child = new Node();
-        child.depth = depth + 1;
-        child.board = parent.board;
-        child.board[depth] <=> child.board[j];
-        pool.pushBack(child);
-        exploredTree += 1;
+    else {
+      for j in depth..(N-1) {
+        if (labels[j + i * N] == 1) {
+          var child = new Node();
+          child.depth = depth + 1;
+          child.board = parent.board;
+          child.board[depth] <=> child.board[j];
+          pool.pushBack(child);
+          exploredTree += 1;
+        }
       }
     }
   }
@@ -156,6 +161,33 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
   pool.pushBack(root);
 
   var timer: stopwatch;
+
+  /*
+    Step 1: We perform a partial breadth-first search on CPU in order to create
+    a sufficiently large amount of work for GPU computation.
+  */
+  timer.start();
+
+  while (pool.size < m) {
+    var hasWork = 0;
+    var parent = pool.popFront(hasWork);
+    if !hasWork then break;
+
+    decompose(parent, exploredTree, exploredSol, best, pool);
+  }
+
+  timer.stop();
+  const res1 = (timer.elapsed(), exploredTree, exploredSol);
+
+  writeln("\nInitial search on CPU completed");
+  writeln("Size of the explored tree: ", res1[1]);
+  writeln("Number of explored solutions: ", res1[2]);
+  writeln("Elapsed time: ", res1[0], " [s]\n");
+
+  /*
+    Step 2: We continue the search on GPU in a depth-first manner until there
+    is not enough work.
+  */
   timer.start();
 
   var parents: [0..#M] Node = noinit;
@@ -165,16 +197,11 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
   on device var labels_d: [0..#(M*N)] uint(8);
 
   while true {
-    var hasWork = 0;
-    var parent = pool.popBack(hasWork);
-    if !hasWork then break;
-
-    decompose(parent, exploredTree, exploredSol, pool);
-
-    var poolSize = min(pool.size, M);
+    var poolSize = pool.size;
 
     // If 'poolSize' is sufficiently large, we offload the pool on GPU.
     if (poolSize >= m) {
+      poolSize = min(poolSize, M);
 
       for i in 0..#poolSize {
         var hasWork = 0;
@@ -185,9 +212,7 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
       const numLabels = N * poolSize;
 
       parents_d = parents; // host-to-device
-      on device {
-        evaluate_gpu(parents_d, numLabels, labels_d);
-      }
+      on device do evaluate_gpu(parents_d, numLabels, labels_d); // GPU kernel
       labels = labels_d; // device-to-host
 
       /*
@@ -195,9 +220,40 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
       */
       generate_children(parents, poolSize, labels, exploredTree, exploredSol, pool);
     }
+    else {
+      break;
+    }
   }
+
+  timer.stop();
+  const res2 = (timer.elapsed(), exploredTree, exploredSol) - res1;
+
+  writeln("Search on GPU completed");
+  writeln("Size of the explored tree: ", res2[1]);
+  writeln("Number of explored solutions: ", res2[2]);
+  writeln("Elapsed time: ", res2[0], " [s]\n");
+
+  /*
+    Step 3: We complete the depth-first search on CPU.
+  */
+  timer.start();
+
+  while true {
+    var hasWork = 0;
+    var parent = pool.popBack(hasWork);
+    if !hasWork then break;
+
+    decompose(parent, exploredTree, exploredSol, best, pool);
+  }
+
   timer.stop();
   elapsedTime = timer.elapsed();
+  const res3 = (elapsedTime, exploredTree, exploredSol) - res1 - res2;
+
+  writeln("Search on CPU completed");
+  writeln("Size of the explored tree: ", res3[1]);
+  writeln("Number of explored solutions: ", res3[2]);
+  writeln("Elapsed time: ", res3[0], " [s]");
 
   writeln("\nExploration terminated.");
 }

--- a/nqueens_gpu_chpl.chpl
+++ b/nqueens_gpu_chpl.chpl
@@ -109,11 +109,10 @@ proc evaluate_gpu(const parents_d: [] Node, const size, ref labels_d)
     // If child 'k' is not scheduled, we evaluate its safety 'G' times, otherwise 0.
     if (k >= depth) {
       isSafe = 1;
-      /* const G_notScheduled = g * (k >= depth); */
       for i in 0..#depth {
         const pbi = parent.board[i];
 
-        for _g in 0..#g {//G_notScheduled {
+        for _g in 0..#g {
           isSafe *= (pbi != queen_num - (depth - i) &&
                      pbi != queen_num + (depth - i));
         }
@@ -199,14 +198,6 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
     var poolSize = pool.popBackBulk(m, M, parents);
 
     if (poolSize > 0) {
-      /* poolSize = min(poolSize, M);
-
-      for i in 0..#poolSize {
-        var hasWork = 0;
-        parents[i] = pool.popBack(hasWork);
-        if !hasWork then break;
-      } */
-
       const numLabels = N * poolSize;
 
       parents_d = parents; // host-to-device

--- a/nqueens_gpu_chpl.chpl
+++ b/nqueens_gpu_chpl.chpl
@@ -72,7 +72,7 @@ proc isSafe(const board, const queen_num, const row_pos): uint(8)
 }
 
 // Evaluate and generate children nodes on CPU.
-proc decompose(const parent: Node, ref tree_loc: uint, ref num_sol: uint, ref pool: SinglePool(Node))
+proc decompose(const parent: Node, ref tree_loc: uint, ref num_sol: uint, ref pool)
 {
   const depth = parent.depth;
 
@@ -124,7 +124,7 @@ proc evaluate_gpu(const parents_d: [] Node, const size, ref labels_d)
 
 // Generate children nodes (evaluated on GPU) on CPU.
 proc generate_children(const ref parents: [] Node, const size: int, const ref labels: [] uint(8),
-  ref exploredTree: uint, ref exploredSol: uint, ref pool: SinglePool(Node))
+  ref exploredTree: uint, ref exploredSol: uint, ref pool)
 {
   for i in 0..#size  {
     const parent = parents[i];

--- a/nqueens_gpu_chpl.chpl
+++ b/nqueens_gpu_chpl.chpl
@@ -3,11 +3,10 @@
 */
 
 use Time;
+use GpuDiagnostics;
 
 use util;
 use Pool;
-use GpuDiagnostics;
-
 use NQueens_node;
 
 config const BLOCK_SIZE = 512;
@@ -173,7 +172,7 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
     var parent = pool.popFront(hasWork);
     if !hasWork then break;
 
-    decompose(parent, exploredTree, exploredSol, best, pool);
+    decompose(parent, exploredTree, exploredSol, pool);
   }
 
   timer.stop();
@@ -197,17 +196,16 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
   on device var labels_d: [0..#(M*N)] uint(8);
 
   while true {
-    var poolSize = pool.size;
+    var poolSize = pool.popBackBulk(m, M, parents);
 
-    // If 'poolSize' is sufficiently large, we offload the pool on GPU.
-    if (poolSize >= m) {
-      poolSize = min(poolSize, M);
+    if (poolSize > 0) {
+      /* poolSize = min(poolSize, M);
 
       for i in 0..#poolSize {
         var hasWork = 0;
         parents[i] = pool.popBack(hasWork);
         if !hasWork then break;
-      }
+      } */
 
       const numLabels = N * poolSize;
 
@@ -243,7 +241,7 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
     var parent = pool.popBack(hasWork);
     if !hasWork then break;
 
-    decompose(parent, exploredTree, exploredSol, best, pool);
+    decompose(parent, exploredTree, exploredSol, pool);
   }
 
   timer.stop();

--- a/nqueens_gpu_chpl.chpl
+++ b/nqueens_gpu_chpl.chpl
@@ -83,10 +83,9 @@ proc decompose(const parent: Node, ref tree_loc: uint, ref num_sol: uint, ref po
   for j in depth..(N-1) {
     if isSafe(parent.board, depth, parent.board[j]) {
       var child = new Node();
-      child.depth = parent.depth;
+      child.depth = depth + 1;
       child.board = parent.board;
       child.board[depth] <=> child.board[j];
-      child.depth += 1;
       pool.pushBack(child);
       tree_loc += 1;
     }
@@ -159,6 +158,12 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
   var timer: stopwatch;
   timer.start();
 
+  var parents: [0..#M] Node = noinit;
+  var labels: [0..#(M*N)] uint(8) = noinit;
+
+  on device var parents_d: [0..#M] Node;
+  on device var labels_d: [0..#(M*N)] uint(8);
+
   while true {
     var hasWork = 0;
     var parent = pool.popBack(hasWork);
@@ -171,7 +176,6 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
     // If 'poolSize' is sufficiently large, we offload the pool on GPU.
     if (poolSize >= m) {
 
-      var parents: [0..#poolSize] Node = noinit;
       for i in 0..#poolSize {
         var hasWork = 0;
         parents[i] = pool.popBack(hasWork);
@@ -179,14 +183,12 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
       }
 
       const numLabels = N * poolSize;
-      var labels: [0..#numLabels] uint(8) = noinit;
 
+      parents_d = parents; // host-to-device
       on device {
-        const parents_d = parents; // host-to-device
-        var labels_d: [0..#numLabels] uint(8) = noinit;
         evaluate_gpu(parents_d, numLabels, labels_d);
-        labels = labels_d; // device-to-host
       }
+      labels = labels_d; // device-to-host
 
       /*
         Each task generates and inserts its children nodes to the pool.

--- a/nqueens_multigpu_chpl.chpl
+++ b/nqueens_multigpu_chpl.chpl
@@ -135,14 +135,16 @@ proc generate_children(const ref parents: [] Node, const size: int, const ref la
     if (depth == N) {
       exploredSol += 1;
     }
-    for j in depth..(N-1) {
-      if (labels[j + i * N] == 1) {
-        var child = new Node();
-        child.depth = depth + 1;
-        child.board = parent.board;
-        child.board[depth] <=> child.board[j];
-        pool.pushBackFree(child);
-        exploredTree += 1;
+    else {
+      for j in depth..(N-1) {
+        if (labels[j + i * N] == 1) {
+          var child = new Node();
+          child.depth = depth + 1;
+          child.board = parent.board;
+          child.board[depth] <=> child.board[j];
+          pool.pushBackFree(child);
+          exploredTree += 1;
+        }
       }
     }
   }

--- a/nqueens_multigpu_chpl.chpl
+++ b/nqueens_multigpu_chpl.chpl
@@ -5,7 +5,7 @@
 use Time;
 
 use util;
-use Pool;
+use Pool_par;
 use GpuDiagnostics;
 
 use NQueens_node;
@@ -74,7 +74,7 @@ proc isSafe(const board, const queen_num, const row_pos): uint(8)
 }
 
 // Evaluate and generate children nodes on CPU.
-proc decompose(const parent: Node, ref tree_loc: uint, ref num_sol: uint, ref pool: SinglePool(Node))
+proc decompose(const parent: Node, ref tree_loc: uint, ref num_sol: uint, ref pool)
 {
   const depth = parent.depth;
 
@@ -124,7 +124,7 @@ proc evaluate_gpu(const parents_d: [] Node, const size, ref labels_d)
 
 // Generate children nodes (evaluated on GPU) on CPU.
 proc generate_children(const ref parents: [] Node, const size: int, const ref labels: [] uint(8),
-  ref exploredTree: uint, ref exploredSol: uint, ref pool: SinglePool(Node))
+  ref exploredTree: uint, ref exploredSol: uint, ref pool)
 {
   for i in 0..#size  {
     const parent = parents[i];
@@ -151,7 +151,7 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
 {
   var root = new Node(N);
 
-  var pool = new SinglePool(Node);
+  var pool = new SinglePool_par(Node);
 
   pool.pushBack(root);
 
@@ -164,7 +164,7 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
   timer.start();
   while (pool.size < D*m) {
     var hasWork = 0;
-    var parent = pool.popFront(hasWork);
+    var parent = pool.popFrontFree(hasWork);
     if !hasWork then break;
 
     decompose(parent, exploredTree, exploredSol, pool);
@@ -192,12 +192,15 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
   pool.front = 0;
   pool.size = 0;
 
-  coforall gpuID in 0..#D with (ref pool, ref eachExploredTree, ref eachExploredSol) {
+  var multiPool: [0..#D] SinglePool_par(Node);
+
+  coforall gpuID in 0..#D with (ref pool, ref eachExploredTree, ref eachExploredSol,
+    ref multiPool) {
 
     const device = here.gpus[gpuID];
 
     var tree, sol: uint;
-    var pool_loc = new SinglePool(Node);
+    ref pool_loc = multiPool[gpuID];
 
     // each task gets its chunk
     pool_loc.elements[0..#c] = pool.elements[gpuID+f.. by D #c];
@@ -217,15 +220,16 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
       /*
         Each task gets its parents nodes from the pool.
       */
-      var poolSize = pool_loc.size;
-      if (poolSize >= m) {
-        poolSize = min(poolSize, M);
+      var poolSize = pool_loc.popBackBulk(m, M, parents);
+
+      if (poolSize > 0) {
+        /* poolSize = min(poolSize, M);
 
         for i in 0..#poolSize {
           var hasWork = 0;
           parents[i] = pool_loc.popBack(hasWork);
           if !hasWork then break;
-        }
+        } */
 
         const numLabels = N * poolSize;
 
@@ -277,7 +281,7 @@ proc nqueens_search(ref exploredTree: uint, ref exploredSol: uint, ref elapsedTi
   timer.start();
   while true {
     var hasWork = 0;
-    var parent = pool.popBack(hasWork);
+    var parent = pool.popBackFree(hasWork);
     if !hasWork then break;
 
     decompose(parent, exploredTree, exploredSol, pool);


### PR DESCRIPTION
This PR implements an intra-node work stealing mechanism for the NQueens problem (similarly to the PFSP). The `on here.gpus[...] var ...;` synthax of Chapel is used to allocate CPU/GPU arrays independently from the iterations and scopes. Previously, class wrappers were used but seemed to produce some unexpected performance issues.

While there, the PR also fixes both Chapel and CUDA single-GPU versions that were not performing the initial partial BFS, as in multi-GPU versions. This now allows a fair comparison against both.

